### PR TITLE
Update deliver-snapshot-cli.md

### DIFF
--- a/doc_source/deliver-snapshot-cli.md
+++ b/doc_source/deliver-snapshot-cli.md
@@ -281,7 +281,7 @@ The response lists the status of all the three delivery formats that AWS Config 
 Take a look at the `lastSuccessfulTime` field in `configSnapshotDeliveryInfo`\. The time should match the time you last requested the delivery of the configuration snapshot\.
 
 **Note**  
-AWS Config uses the UTC format \(GMT\-08:00\) to record the time\.
+AWS Config uses the UTC format to record the time\.
 
 ## Viewing Configuration Snapshot in Amazon S3 bucket<a name="view-configuration-snapshot"></a>
 


### PR DESCRIPTION
Removed reference to GMT-08:00.
UTC is a standard that matches GMT timezone (GMT+0)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
