### PR TITLE
Fixing reference to reflect actual requirement

### DIFF
--- a/doc_source/aws-config-managed-rules-cloudformation-templates.md
+++ b/doc_source/aws-config-managed-rules-cloudformation-templates.md
@@ -13,7 +13,7 @@ For more information about working with AWS CloudFormation templates, see [Getti
 
 1. For **Specify template**: 
    + If you downloaded the template, choose **Upload a template file**, and then **Choose file** to upload the template\.
-   + You can also choose **Amazon S3 URL**, and enter the template URL `s3.amazonaws.com/aws-configservice-us-east-1/cloudformation-templates-for-managed-rules/THE_RULE_IDENTIFIER.template`\. 
+   + You can also choose **Amazon S3 URL**, and enter the template URL `http://s3.amazonaws.com/aws-configservice-us-east-1/cloudformation-templates-for-managed-rules/THE_RULE_IDENTIFIER.template`\. 
 **Note**  
 The rule identifier should be written in ALL\_CAPS\_WITH\_UNDERSCORES\. For example, CLOUDWATCH\_LOG\_GROUP\_ENCRYPTED instead of cloudwatch\-log\-group\-encrypted\.  
 For some rules, the rule identifier is **different** from the rule name\. Make sure for use the rule identifier\. For example, the rule identifier for restricted\-ssh is INCOMING\_SSH\_DISABLED\.


### PR DESCRIPTION
*Description of changes:*
The previous reference to an s3 bucket location does not work when used as the Amazon s3 URL in cloudformation. By pre-pending 'http://' the reference to template files is now recognised by cloudformation instantly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
