### PR TITLE
Added tool to convert Markdown to structured YAML format

### DIFF
--- a/config-rules.yml
+++ b/config-rules.yml
@@ -1,0 +1,5964 @@
+- AWSRegion: All supported AWS regions
+  Description: "Checks if the active access keys are rotated within the number of\
+    \ days specified in `maxAccessKeyAge`\\. The rule is NON\\_COMPLIANT if the access\
+    \ keys have not been rotated for more than `maxAccessKeyAge` number of days\\\
+    .\n\n**Note**  \nThis rule requires you to turn on 'Include global resources'\
+    \ in general settings in order for resources to be evaluated\\.  \nRe\\-evaluating\
+    \ this rule within 4 hours of the first evaluation will have no effect on the\
+    \ results\\."
+  File: access-keys-rotated.md
+  FullDocumentation: "# access\\-keys\\-rotated<a name=\"access-keys-rotated\"></a>\n\
+    \nChecks if the active access keys are rotated within the number of days specified\
+    \ in `maxAccessKeyAge`\\. The rule is NON\\_COMPLIANT if the access keys have\
+    \ not been rotated for more than `maxAccessKeyAge` number of days\\.\n\n**Note**\
+    \  \nThis rule requires you to turn on 'Include global resources' in general settings\
+    \ in order for resources to be evaluated\\.  \nRe\\-evaluating this rule within\
+    \ 4 hours of the first evaluation will have no effect on the results\\.\n\n**Identifier:**\
+    \ ACCESS\\_KEYS\\_ROTATED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All\
+    \ supported AWS regions\n\n**Parameters:**\n\nmaxAccessKeyAgeType: intDefault:\
+    \ 90  \nMaximum number of days without rotation\\. Default 90\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7b1c17\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ACCESS_KEYS_ROTATED
+  Name: access-keys-rotated
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if an AWS account is part of AWS Organizations\. The rule is
+    NON\_COMPLIANT if an AWS account is not part of AWS Organizations or AWS Organizations
+    master account ID does not match rule parameter `MasterAccountId`\.
+  File: account-part-of-organizations.md
+  FullDocumentation: "# account\\-part\\-of\\-organizations<a name=\"account-part-of-organizations\"\
+    ></a>\n\nChecks if an AWS account is part of AWS Organizations\\. The rule is\
+    \ NON\\_COMPLIANT if an AWS account is not part of AWS Organizations or AWS Organizations\
+    \ master account ID does not match rule parameter `MasterAccountId`\\.\n\n**Identifier:**\
+    \ ACCOUNT\\_PART\\_OF\\_ORGANIZATIONS\n\n**Trigger type:** Periodic\n\n**AWS Region:**\
+    \ All supported AWS regions except China \\(Beijing\\), Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nMasterAccountId \\(Optional\\\
+    )Type: String  \nThe master account ID for an AWS account\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7b3c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ACCOUNT_PART_OF_ORGANIZATIONS
+  Name: account-part-of-organizations
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    Asia Pacific \(Osaka\), Europe \(Milan\) Region
+  Description: Checks if AWS Certificate Manager Certificates in your account are
+    marked for expiration within the specified number of days\. Certificates provided
+    by ACM are automatically renewed\. ACM does not automatically renew certificates
+    that you import\. The rule is NON\_COMPLIANT if your certificates are about to
+    expire\.
+  File: acm-certificate-expiration-check.md
+  FullDocumentation: "# acm\\-certificate\\-expiration\\-check<a name=\"acm-certificate-expiration-check\"\
+    ></a>\n\nChecks if AWS Certificate Manager Certificates in your account are marked\
+    \ for expiration within the specified number of days\\. Certificates provided\
+    \ by ACM are automatically renewed\\. ACM does not automatically renew certificates\
+    \ that you import\\. The rule is NON\\_COMPLIANT if your certificates are about\
+    \ to expire\\.\n\n**Identifier:** ACM\\_CERTIFICATE\\_EXPIRATION\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), Asia Pacific \\(Osaka\\), Europe \\\
+    (Milan\\) Region\n\n**Parameters:**\n\ndaysToExpiration \\(Optional\\)Type: intDefault:\
+    \ 14  \nSpecify the number of days before the rule flags the ACM Certificate as\
+    \ noncompliant\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7b5c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ACM_CERTIFICATE_EXPIRATION_CHECK
+  Name: acm-certificate-expiration-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if rule evaluates AWS Application Load Balancers \(ALB\) to
+    ensure they are configured to drop http headers\. The rule is NON\_COMPLIANT if
+    the value of routing\.http\.drop\_invalid\_header\_fields\.enabled is set to false\.
+  File: alb-http-drop-invalid-header-enabled.md
+  FullDocumentation: "# alb\\-http\\-drop\\-invalid\\-header\\-enabled<a name=\"alb-http-drop-invalid-header-enabled\"\
+    ></a>\n\nChecks if rule evaluates AWS Application Load Balancers \\(ALB\\) to\
+    \ ensure they are configured to drop http headers\\. The rule is NON\\_COMPLIANT\
+    \ if the value of routing\\.http\\.drop\\_invalid\\_header\\_fields\\.enabled\
+    \ is set to false\\. \n\n**Identifier:** ALB\\_HTTP\\_DROP\\_INVALID\\_HEADER\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7b7c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ALB_HTTP_DROP_INVALID_HEADER_ENABLED
+  Name: alb-http-drop-invalid-header-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if HTTP to HTTPS redirection is configured on all HTTP listeners
+    of Application Load Balancers\. The rule is NON\_COMPLIANT if one or more HTTP
+    listeners of Application Load Balancer do not have HTTP to HTTPS redirection configured\.
+    The rule is also NON\_COMPLIANT if one of more HTTP listeners have forwarding
+    to an HTTP listener instead of redirection\.
+  File: alb-http-to-https-redirection-check.md
+  FullDocumentation: "# alb\\-http\\-to\\-https\\-redirection\\-check<a name=\"alb-http-to-https-redirection-check\"\
+    ></a>\n\nChecks if HTTP to HTTPS redirection is configured on all HTTP listeners\
+    \ of Application Load Balancers\\. The rule is NON\\_COMPLIANT if one or more\
+    \ HTTP listeners of Application Load Balancer do not have HTTP to HTTPS redirection\
+    \ configured\\. The rule is also NON\\_COMPLIANT if one of more HTTP listeners\
+    \ have forwarding to an HTTP listener instead of redirection\\.\n\n**Identifier:**\
+    \ ALB\\_HTTP\\_TO\\_HTTPS\\_REDIRECTION\\_CHECK\n\n**Trigger type:** Periodic\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7b9c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ALB_HTTP_TO_HTTPS_REDIRECTION_CHECK
+  Name: alb-http-to-https-redirection-check
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: 'Checks if Web Application Firewall \(WAF\) is enabled on Application
+    Load Balancers \(ALBs\)\. This rule is NON\_COMPLIANT if key: waf\.enabled is
+    set to false\.'
+  File: alb-waf-enabled.md
+  FullDocumentation: "# alb\\-waf\\-enabled<a name=\"alb-waf-enabled\"></a>\n\nChecks\
+    \ if Web Application Firewall \\(WAF\\) is enabled on Application Load Balancers\
+    \ \\(ALBs\\)\\. This rule is NON\\_COMPLIANT if key: waf\\.enabled is set to false\\\
+    . \n\n**Identifier:** ALB\\_WAF\\_ENABLED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except China \\(Beijing\\), China\
+    \ \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa\
+    \ \\(Cape Town\\) Region\n\n**Parameters:**\n\nwafWebAclIds \\(Optional\\)Type:\
+    \ CSV  \nComma separated list of web ACL ID \\(for WAF\\) or web ACL ARN \\(for\
+    \ WAFV2\\) checking for ALB association\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7c11c15\"></a>\n\nTo create AWS Config managed rules with\
+    \ AWS CloudFormation templates, see [Creating AWS Config Managed Rules With AWS\
+    \ CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ALB_WAF_ENABLED
+  Name: alb-waf-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if an Amazon API Gateway API stage is using an AWS WAF Web ACL\.
+    This rule is NON\_COMPLIANT if an AWS WAF Web ACL is not used or if a used AWS
+    Web ACL does not match what is listed in the rule parameter\.
+  File: api-gw-associated-with-waf.md
+  FullDocumentation: "# api\\-gw\\-associated\\-with\\-waf<a name=\"api-gw-associated-with-waf\"\
+    ></a>\n\nChecks if an Amazon API Gateway API stage is using an AWS WAF Web ACL\\\
+    . This rule is NON\\_COMPLIANT if an AWS WAF Web ACL is not used or if a used\
+    \ AWS Web ACL does not match what is listed in the rule parameter\\. \n\n**Identifier:**\
+    \ API\\_GW\\_ASSOCIATED\\_WITH\\_WAF\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except China \\(Beijing\\), China\
+    \ \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\n\
+    WebAclArns \\(Optional\\)Type: CSV  \nComma\\-separated list of web ACL Amazon\
+    \ Resource Names \\(ARNs\\)\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c13c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: API_GW_ASSOCIATED_WITH_WAF
+  Name: api-gw-associated-with-waf
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks that all methods in Amazon API Gateway stages have cache enabled
+    and cache encrypted\. The rule is NON\_COMPLIANT if any method in Amazon API Gateway
+    stage is not configured to cache or the cache is not encrypted\.
+  File: api-gw-cache-enabled-and-encrypted.md
+  FullDocumentation: "# api\\-gw\\-cache\\-enabled\\-and\\-encrypted<a name=\"api-gw-cache-enabled-and-encrypted\"\
+    ></a>\n\nChecks that all methods in Amazon API Gateway stages have cache enabled\
+    \ and cache encrypted\\. The rule is NON\\_COMPLIANT if any method in Amazon API\
+    \ Gateway stage is not configured to cache or the cache is not encrypted\\. \n\
+    \n**Identifier:** API\\_GW\\_CACHE\\_ENABLED\\_AND\\_ENCRYPTED\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa\
+    \ \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c15c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: API_GW_CACHE_ENABLED_AND_ENCRYPTED
+  Name: api-gw-cache-enabled-and-encrypted
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if Amazon API Gateway APIs are of the type specified in the
+    rule parameter `endpointConfigurationType`\. The rule returns NON\_COMPLIANT if
+    the REST API does not match the endpoint type configured in the rule parameter\.
+  File: api-gw-endpoint-type-check.md
+  FullDocumentation: "# api\\-gw\\-endpoint\\-type\\-check<a name=\"api-gw-endpoint-type-check\"\
+    ></a>\n\nChecks if Amazon API Gateway APIs are of the type specified in the rule\
+    \ parameter `endpointConfigurationType`\\. The rule returns NON\\_COMPLIANT if\
+    \ the REST API does not match the endpoint type configured in the rule parameter\\\
+    .\n\n**Identifier:** API\\_GW\\_ENDPOINT\\_TYPE\\_CHECK\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\\
+    ) Region\n\n**Parameters:**\n\nendpointConfigurationTypesType: String  \nComma\\\
+    -separated list of allowed endpointConfigurationTypes\\. Allowed values are REGIONAL,\
+    \ PRIVATE and EDGE\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c17c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: API_GW_ENDPOINT_TYPE_CHECK
+  Name: api-gw-endpoint-type-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks that all methods in Amazon API Gateway stage has logging enabled\.
+    The rule is NON\_COMPLIANT if logging is not enabled\. The rule is NON\_COMPLIANT
+    if `loggingLevel` is neither ERROR nor INFO\.
+  File: api-gw-execution-logging-enabled.md
+  FullDocumentation: "# api\\-gw\\-execution\\-logging\\-enabled<a name=\"api-gw-execution-logging-enabled\"\
+    ></a>\n\nChecks that all methods in Amazon API Gateway stage has logging enabled\\\
+    . The rule is NON\\_COMPLIANT if logging is not enabled\\. The rule is NON\\_COMPLIANT\
+    \ if `loggingLevel` is neither ERROR nor INFO\\. \n\n**Identifier:** API\\_GW\\\
+    _EXECUTION\\_LOGGING\\_ENABLED\n\n**Trigger type:** Configuration changes\n\n\
+    **AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nloggingLevel \\(Optional\\)Type: StringDefault: ERROR,INFO  \nComma\\-separated\
+    \ list of specific logging levels \\(for example, ERROR, INFO or ERROR,INFO\\\
+    )\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c19c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: API_GW_EXECUTION_LOGGING_ENABLED
+  Name: api-gw-execution-logging-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if a REST API stage uses an Secure Sockets Layer \(SSL\) certificate\.
+    This rule is NON\_COMPLIANT if the REST API stage does not have an associated
+    SSL certificate\.
+  File: api-gw-ssl-enabled.md
+  FullDocumentation: "# api\\-gw\\-ssl\\-enabled<a name=\"api-gw-ssl-enabled\"></a>\n\
+    \nChecks if a REST API stage uses an Secure Sockets Layer \\(SSL\\) certificate\\\
+    . This rule is NON\\_COMPLIANT if the REST API stage does not have an associated\
+    \ SSL certificate\\. \n\n**Identifier:** API\\_GW\\_SSL\\_ENABLED\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS\
+    \ GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\\
+    ) Region\n\n**Parameters:**\n\nCertificateIDs \\(Optional\\)Type: CSV  \nComma\\\
+    -separated list of client certificate IDs configured on a REST API stage\\.\n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7c21c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: API_GW_SSL_ENABLED
+  Name: api-gw-ssl-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if AWS X\-Ray tracing is enabled on Amazon API Gateway REST
+    APIs\. The rule is COMPLIANT if X\-Ray tracing is enabled and NON\_COMPLIANT otherwise\.
+  File: api-gw-xray-enabled.md
+  FullDocumentation: "# api\\-gw\\-xray\\-enabled<a name=\"api-gw-xray-enabled\"></a>\n\
+    \nChecks if AWS X\\-Ray tracing is enabled on Amazon API Gateway REST APIs\\.\
+    \ The rule is COMPLIANT if X\\-Ray tracing is enabled and NON\\_COMPLIANT otherwise\\\
+    . \n\n**Identifier:** API\\_GW\\_XRAY\\_ENABLED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except China \\(Beijing\\\
+    ), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\\
+    ), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c23c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: API_GW_XRAY_ENABLED
+  Name: api-gw-xray-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if running instances are using specified AMIs\. Specify a list
+    of approved AMI IDs\. Running instances with AMIs that are not on this list are
+    NON\_COMPLIANT\.
+  File: approved-amis-by-id.md
+  FullDocumentation: "# approved\\-amis\\-by\\-id<a name=\"approved-amis-by-id\"></a>\n\
+    \nChecks if running instances are using specified AMIs\\. Specify a list of approved\
+    \ AMI IDs\\. Running instances with AMIs that are not on this list are NON\\_COMPLIANT\\\
+    .\n\n**Identifier:** APPROVED\\_AMIS\\_BY\\_ID\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    amiIdsType: CSV  \nThe AMI IDs \\(comma\\-separated list of up to 10\\)\\.\n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7c25c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: APPROVED_AMIS_BY_ID
+  Name: approved-amis-by-id
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if running instances are using specified AMIs\. Specify the
+    tags that identify the AMIs\. Running instances with AMIs that don't have at least
+    one of the specified tags are NON\_COMPLIANT\.
+  File: approved-amis-by-tag.md
+  FullDocumentation: "# approved\\-amis\\-by\\-tag<a name=\"approved-amis-by-tag\"\
+    ></a>\n\nChecks if running instances are using specified AMIs\\. Specify the tags\
+    \ that identify the AMIs\\. Running instances with AMIs that don't have at least\
+    \ one of the specified tags are NON\\_COMPLIANT\\.\n\n**Identifier:** APPROVED\\\
+    _AMIS\\_BY\\_TAG\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions\n\n**Parameters:**\n\namisByTagKeyAndValueType: StringMapDefault:\
+    \ tag\\-key:tag\\-value,other\\-tag\\-key  \nThe AMIs by tag \\(comma\\-separated\
+    \ list up to 10; for example,`tag-key:tag-value`; i\\.e\\. `tag-key1` matches\
+    \ AMIs with `tag-key1`,`tag-key2:value2` matches `tag-key2` having value2\\)\\\
+    .\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c27c15\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: APPROVED_AMIS_BY_TAG
+  Name: approved-amis-by-tag
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Hong Kong\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Europe \(Stockholm\),
+    Middle East \(Bahrain\), Africa \(Cape Town\), South America \(Sao Paulo\) Region
+  Description: Checks if an Amazon Aurora MySQL cluster has backtracking enabled\.
+    This rule is NON\_COMPLIANT if the Aurora cluster uses MySQL and it does not have
+    backtracking enabled\.
+  File: aurora-mysql-backtracking-enabled.md
+  FullDocumentation: "# aurora\\-mysql\\-backtracking\\-enabled<a name=\"aurora-mysql-backtracking-enabled\"\
+    ></a>\n\nChecks if an Amazon Aurora MySQL cluster has backtracking enabled\\.\
+    \ This rule is NON\\_COMPLIANT if the Aurora cluster uses MySQL and it does not\
+    \ have backtracking enabled\\. \n\n**Identifier:** AURORA\\_MYSQL\\_BACKTRACKING\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\\
+    (US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Hong Kong\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Europe\
+    \ \\(Stockholm\\), Middle East \\(Bahrain\\), Africa \\(Cape Town\\), South America\
+    \ \\(Sao Paulo\\) Region\n\n**Parameters:**\n\nBacktrackWindowInHours \\(Optional\\\
+    )Type: double  \nAmount of time in hours \\(up to 72\\) to backtrack your Aurora\
+    \ MySQL cluster\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c29c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: AURORA_MYSQL_BACKTRACKING_ENABLED
+  Name: aurora-mysql-backtracking-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon Aurora DB clusters are protected by a backup plan\.
+    The rule is NON\_COMPLIANT if the Amazon Relational Database Service \(Amazon
+    RDS\) Database Cluster is not protected by a backup plan\.
+  File: aurora-resources-protected-by-backup-plan.md
+  FullDocumentation: "# aurora\\-resources\\-protected\\-by\\-backup\\-plan<a name=\"\
+    aurora-resources-protected-by-backup-plan\"></a>\n\nChecks if Amazon Aurora DB\
+    \ clusters are protected by a backup plan\\. The rule is NON\\_COMPLIANT if the\
+    \ Amazon Relational Database Service \\(Amazon RDS\\) Database Cluster is not\
+    \ protected by a backup plan\\. \n\n**Identifier:** AURORA\\_RESOURCES\\_PROTECTED\\\
+    _BY\\_BACKUP\\_PLAN\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape\
+    \ Town\\) Region\n\n**Parameters:**\n\nresourceTags \\(Optional\\)Type: String\
+    \  \nTags of Aurora DB clusters for the rule to check, in JSON format\\.\n\nresourceId\
+    \ \\(Optional\\)Type: String  \nID of Aurora DB cluster for the rule to check\\\
+    .\n\ncrossRegionList \\(Optional\\)Type: String  \nComma\\-separated list of destination\
+    \ regions for the cross\\-region backup copy to be kept\n\ncrossAccountList \\\
+    (Optional\\)Type: String  \nComma\\-separated list of destination accounts for\
+    \ cross\\-account backup copy to be kept\n\nmaxRetentionDays \\(Optional\\)Type:\
+    \ int  \nThe maximum retention period in days for the Backup Vault Lock\n\nminRetentionDays\
+    \ \\(Optional\\)Type: int  \nThe minimum retention period in days for the Backup\
+    \ Vault Lock\n\nbackupVaultLockCheck \\(Optional\\)Type: String  \nAccepted values:\
+    \ 'True' or 'False'\\. Enter 'True' for the rule to check if the resource is backed\
+    \ up in a locked vault\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c31c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: AURORA_RESOURCES_PROTECTED_BY_BACKUP_PLAN
+  Name: aurora-resources-protected-by-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks whether your Auto Scaling groups that are associated with a
+    load balancer are using Elastic Load Balancing health checks\.
+  File: autoscaling-group-elb-healthcheck-required.md
+  FullDocumentation: "# autoscaling\\-group\\-elb\\-healthcheck\\-required<a name=\"\
+    autoscaling-group-elb-healthcheck-required\"></a>\n\nChecks whether your Auto\
+    \ Scaling groups that are associated with a load balancer are using Elastic Load\
+    \ Balancing health checks\\. \n\n**Identifier:** AUTOSCALING\\_GROUP\\_ELB\\_HEALTHCHECK\\\
+    _REQUIRED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7c33c15\"></a>\n\nTo create AWS Config managed rules with\
+    \ AWS CloudFormation templates, see [Creating AWS Config Managed Rules With AWS\
+    \ CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: AUTOSCALING_GROUP_ELB_HEALTHCHECK_REQUIRED
+  Name: autoscaling-group-elb-healthcheck-required
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), AWS GovCloud
+    \(US\-West\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\) Region
+  Description: Checks if Amazon EC2 Auto Scaling groups have public IP addresses enabled
+    through Launch Configurations\. This rule is NON\_COMPLIANT if the Launch Configuration
+    for an Auto Scaling group has AssociatePublicIpAddress set to 'true'\.
+  File: autoscaling-launch-config-public-ip-disabled.md
+  FullDocumentation: "# autoscaling\\-launch\\-config\\-public\\-ip\\-disabled<a name=\"\
+    autoscaling-launch-config-public-ip-disabled\"></a>\n\nChecks if Amazon EC2 Auto\
+    \ Scaling groups have public IP addresses enabled through Launch Configurations\\\
+    . This rule is NON\\_COMPLIANT if the Launch Configuration for an Auto Scaling\
+    \ group has AssociatePublicIpAddress set to 'true'\\. \n\n**Identifier:** AUTOSCALING\\\
+    _LAUNCH\\_CONFIG\\_PUBLIC\\_IP\\_DISABLED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except AWS GovCloud \\(US\\-East\\\
+    ), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\\
+    ) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7c35c15\"></a>\n\nTo create AWS Config managed rules with AWS CloudFormation\
+    \ templates, see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: AUTOSCALING_LAUNCH_CONFIG_PUBLIC_IP_DISABLED
+  Name: autoscaling-launch-config-public-ip-disabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if the Auto Scaling group spans multiple Availability Zones\.
+    The rule is NON\_COMPLIANT if the Auto Scaling group does not span multiple Availability
+    Zones\.
+  File: autoscaling-multiple-az.md
+  FullDocumentation: "# autoscaling\\-multiple\\-az<a name=\"autoscaling-multiple-az\"\
+    ></a>\n\nChecks if the Auto Scaling group spans multiple Availability Zones\\\
+    . The rule is NON\\_COMPLIANT if the Auto Scaling group does not span multiple\
+    \ Availability Zones\\. \n\n**Identifier:** AUTOSCALING\\_MULTIPLE\\_AZ\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\nminAvailabilityZones \\(Optional\\)Type: int  \nMinimum number\
+    \ of expected Availability zones\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7c37c15\"></a>\n\nTo create AWS Config managed rules with AWS CloudFormation\
+    \ templates, see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: AUTOSCALING_MULTIPLE_AZ
+  Name: autoscaling-multiple-az
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if a backup plan has a backup rule that satisfies the required
+    frequency and retention period\. The rule is NON\_COMPLIANT if recovery points
+    are not created at least as often as the specified frequency or expire before
+    the specified period\.
+  File: backup-plan-min-frequency-and-min-retention-check.md
+  FullDocumentation: "# backup\\-plan\\-min\\-frequency\\-and\\-min\\-retention\\\
+    -check<a name=\"backup-plan-min-frequency-and-min-retention-check\"></a>\n\nChecks\
+    \ if a backup plan has a backup rule that satisfies the required frequency and\
+    \ retention period\\. The rule is NON\\_COMPLIANT if recovery points are not created\
+    \ at least as often as the specified frequency or expire before the specified\
+    \ period\\. \n\n**Identifier:** BACKUP\\_PLAN\\_MIN\\_FREQUENCY\\_AND\\_MIN\\\
+    _RETENTION\\_CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\\
+    ), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nrequiredFrequencyValue\
+    \ \\(Optional\\)Type: intDefault: 1  \nNumerical value for required backup frequency\\\
+    . Maximum of 24 for hours, 31 for days\\.\n\nrequiredRetentionDays \\(Optional\\\
+    )Type: intDefault: 35  \nRequired retention period in days\\.\n\nrequiredFrequencyUnit\
+    \ \\(Optional\\)Type: StringDefault: days  \nUnit of time for required backup\
+    \ frequency\\. Accepted values: 'hours', 'days'\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7c39c15\"></a>\n\nTo create AWS Config managed rules with\
+    \ AWS CloudFormation templates, see [Creating AWS Config Managed Rules With AWS\
+    \ CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: BACKUP_PLAN_MIN_FREQUENCY_AND_MIN_RETENTION_CHECK
+  Name: backup-plan-min-frequency-and-min-retention-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if a recovery point is encrypted\. The rule is NON\_COMPLIANT
+    if the recovery point is not encrypted\.
+  File: backup-recovery-point-encrypted.md
+  FullDocumentation: "# backup\\-recovery\\-point\\-encrypted<a name=\"backup-recovery-point-encrypted\"\
+    ></a>\n\nChecks if a recovery point is encrypted\\. The rule is NON\\_COMPLIANT\
+    \ if the recovery point is not encrypted\\. \n\n**Identifier:** BACKUP\\_RECOVERY\\\
+    _POINT\\_ENCRYPTED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\\
+    ), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c41c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: BACKUP_RECOVERY_POINT_ENCRYPTED
+  Name: backup-recovery-point-encrypted
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if a backup vault has an attached resource\-based policy which
+    prevents deletion of recovery points\. The rule is NON\_COMPLIANT if the Backup
+    Vault does not have resource\-based policies or has policies without a suitable
+    'Deny' statement\.
+  File: backup-recovery-point-manual-deletion-disabled.md
+  FullDocumentation: "# backup\\-recovery\\-point\\-manual\\-deletion\\-disabled<a\
+    \ name=\"backup-recovery-point-manual-deletion-disabled\"></a>\n\nChecks if a\
+    \ backup vault has an attached resource\\-based policy which prevents deletion\
+    \ of recovery points\\. The rule is NON\\_COMPLIANT if the Backup Vault does not\
+    \ have resource\\-based policies or has policies without a suitable 'Deny' statement\\\
+    . \n\n**Identifier:** BACKUP\\_RECOVERY\\_POINT\\_MANUAL\\_DELETION\\_DISABLED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape\
+    \ Town\\) Region\n\n**Parameters:**\n\nprincipalArnList \\(Optional\\)Type: CSV\
+    \  \nComma\\-separated list of AWS Identity and Access Management \\(IAM\\) Amazon\
+    \ Resource Names \\(ARNs\\) for the rule to NOT check\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c43c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: BACKUP_RECOVERY_POINT_MANUAL_DELETION_DISABLED
+  Name: backup-recovery-point-manual-deletion-disabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if a recovery point expires no earlier than after the specified
+    period\. The rule is NON\_COMPLIANT if the recovery point has a retention point
+    that is less than the required retention period\.
+  File: backup-recovery-point-minimum-retention-check.md
+  FullDocumentation: "# backup\\-recovery\\-point\\-minimum\\-retention\\-check<a\
+    \ name=\"backup-recovery-point-minimum-retention-check\"></a>\n\nChecks if a recovery\
+    \ point expires no earlier than after the specified period\\. The rule is NON\\\
+    _COMPLIANT if the recovery point has a retention point that is less than the required\
+    \ retention period\\. \n\n**Identifier:** BACKUP\\_RECOVERY\\_POINT\\_MINIMUM\\\
+    _RETENTION\\_CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\\
+    ), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nrequiredRetentionDays \\\
+    (Optional\\)Type: intDefault: 35  \nRequired retention period in days\\.\n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7c45c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: BACKUP_RECOVERY_POINT_MINIMUM_RETENTION_CHECK
+  Name: backup-recovery-point-minimum-retention-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if an AWS Elastic Beanstalk environment is configured for enhanced
+    health reporting\. The rule is COMPLIANT if the environment is configured for
+    enhanced health reporting\. The rule is NON\_COMPLIANT if the environment is configured
+    for basic health reporting\.
+  File: beanstalk-enhanced-health-reporting-enabled.md
+  FullDocumentation: "# beanstalk\\-enhanced\\-health\\-reporting\\-enabled<a name=\"\
+    beanstalk-enhanced-health-reporting-enabled\"></a>\n\nChecks if an AWS Elastic\
+    \ Beanstalk environment is configured for enhanced health reporting\\. The rule\
+    \ is COMPLIANT if the environment is configured for enhanced health reporting\\\
+    . The rule is NON\\_COMPLIANT if the environment is configured for basic health\
+    \ reporting\\.\n\n**Identifier:** BEANSTALK\\_ENHANCED\\_HEALTH\\_REPORTING\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\\
+    (US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c47c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: BEANSTALK_ENHANCED_HEALTH_REPORTING_ENABLED
+  Name: beanstalk-enhanced-health-reporting-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if a Classic Load Balancer spans multiple Availability Zones
+    \(AZs\)\. The rule is NON\_COMPLIANT if a Classic Load Balancer spans less than
+    2 AZs or does not span number of AZs mentioned in the `minAvailabilityZones` parameter
+    \(if provided\)\.
+  File: clb-multiple-az.md
+  FullDocumentation: "# clb\\-multiple\\-az<a name=\"clb-multiple-az\"></a>\n\nChecks\
+    \ if a Classic Load Balancer spans multiple Availability Zones \\(AZs\\)\\. The\
+    \ rule is NON\\_COMPLIANT if a Classic Load Balancer spans less than 2 AZs or\
+    \ does not span number of AZs mentioned in the `minAvailabilityZones` parameter\
+    \ \\(if provided\\)\\. \n\n**Identifier:** CLB\\_MULTIPLE\\_AZ\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\
+    \nminAvailabilityZones \\(Optional\\)Type: int  \nDesired minimum number of expected\
+    \ AZs\\. Valid values are between 2 and 10, both inclusive\\. Default value is\
+    \ 2 if parameter is not specified\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7c49c15\"></a>\n\nTo create AWS Config managed rules with AWS CloudFormation\
+    \ templates, see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLB_MULTIPLE_AZ
+  Name: clb-multiple-az
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks whether AWS CloudTrail trails are configured to send logs to
+    Amazon CloudWatch logs\. The trail is non\-compliant if the CloudWatchLogsLogGroupArn
+    property of the trail is empty\.
+  File: cloud-trail-cloud-watch-logs-enabled.md
+  FullDocumentation: "# cloud\\-trail\\-cloud\\-watch\\-logs\\-enabled<a name=\"cloud-trail-cloud-watch-logs-enabled\"\
+    ></a>\n\nChecks whether AWS CloudTrail trails are configured to send logs to Amazon\
+    \ CloudWatch logs\\. The trail is non\\-compliant if the CloudWatchLogsLogGroupArn\
+    \ property of the trail is empty\\. \n\n**Identifier:** CLOUD\\_TRAIL\\_CLOUD\\\
+    _WATCH\\_LOGS\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported\
+    \ AWS regions\n\n**Parameters:**\n\nexpectedDeliveryWindowAge \\(Optional\\)Type:\
+    \ int  \nMaximum age in hours of the most recent delivery to CloudWatch logs that\
+    \ satisfies compliance\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c89c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUD_TRAIL_CLOUD_WATCH_LOGS_ENABLED
+  Name: cloud-trail-cloud-watch-logs-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks if AWS CloudTrail is configured to use the server side encryption
+    \(SSE\) AWS Key Management Service KMS key encryption\. The rule is COMPLIANT
+    if the KmsKeyId is defined\.
+  File: cloud-trail-encryption-enabled.md
+  FullDocumentation: "# cloud\\-trail\\-encryption\\-enabled<a name=\"cloud-trail-encryption-enabled\"\
+    ></a>\n\nChecks if AWS CloudTrail is configured to use the server side encryption\
+    \ \\(SSE\\) AWS Key Management Service KMS key encryption\\. The rule is COMPLIANT\
+    \ if the KmsKeyId is defined\\. \n\n**Identifier:** CLOUD\\_TRAIL\\_ENCRYPTION\\\
+    _ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c93c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUD_TRAIL_ENCRYPTION_ENABLED
+  Name: cloud-trail-encryption-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks whether AWS CloudTrail creates a signed digest file with logs\.
+    AWS recommends that the file validation must be enabled on all trails\. The rule
+    is noncompliant if the validation is not enabled\.
+  File: cloud-trail-log-file-validation-enabled.md
+  FullDocumentation: "# cloud\\-trail\\-log\\-file\\-validation\\-enabled<a name=\"\
+    cloud-trail-log-file-validation-enabled\"></a>\n\nChecks whether AWS CloudTrail\
+    \ creates a signed digest file with logs\\. AWS recommends that the file validation\
+    \ must be enabled on all trails\\. The rule is noncompliant if the validation\
+    \ is not enabled\\. \n\n**Identifier:** CLOUD\\_TRAIL\\_LOG\\_FILE\\_VALIDATION\\\
+    _ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c95c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUD_TRAIL_LOG_FILE_VALIDATION_ENABLED
+  Name: cloud-trail-log-file-validation-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Hong Kong\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Europe \(Paris\),
+    Europe \(Stockholm\), Middle East \(Bahrain\), Africa \(Cape Town\) Region
+  Description: Checks if the actual configuration of a Cloud Formation stack differs,
+    or has drifted, from the expected configuration\. A stack is considered to have
+    drifted if one or more of its resources differ from their expected configuration\.
+    The rule and the stack are COMPLIANT when the stack drift status is IN\_SYNC\.
+    The rule and the stack are NON\_COMPLIANT when the stack drift status is DRIFTED\.
+  File: cloudformation-stack-drift-detection-check.md
+  FullDocumentation: "# cloudformation\\-stack\\-drift\\-detection\\-check<a name=\"\
+    cloudformation-stack-drift-detection-check\"></a>\n\nChecks if the actual configuration\
+    \ of a Cloud Formation stack differs, or has drifted, from the expected configuration\\\
+    . A stack is considered to have drifted if one or more of its resources differ\
+    \ from their expected configuration\\. The rule and the stack are COMPLIANT when\
+    \ the stack drift status is IN\\_SYNC\\. The rule and the stack are NON\\_COMPLIANT\
+    \ when the stack drift status is DRIFTED\\.\n\n**Identifier:** CLOUDFORMATION\\\
+    _STACK\\_DRIFT\\_DETECTION\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except China \\(Beijing\\), China\
+    \ \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Hong Kong\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\\
+    ), Europe \\(Milan\\), Europe \\(Paris\\), Europe \\(Stockholm\\), Middle East\
+    \ \\(Bahrain\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\ncloudformationRoleArnType:\
+    \ String  \nThe AWS CloudFormation role ARN with IAM policy permissions to detect\
+    \ drift for AWS CloudFormation Stacks\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7c51c15\"></a>\n\nTo create AWS Config managed rules with AWS CloudFormation\
+    \ templates, see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFORMATION_STACK_DRIFT_DETECTION_CHECK
+  Name: cloudformation-stack-drift-detection-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Hong Kong\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Europe \(Paris\),
+    Europe \(Stockholm\), Middle East \(Bahrain\), Africa \(Cape Town\) Region
+  Description: Checks whether your CloudFormation stacks are sending event notifications
+    to an SNS topic\. Optionally checks whether specified SNS topics are used\.
+  File: cloudformation-stack-notification-check.md
+  FullDocumentation: "# cloudformation\\-stack\\-notification\\-check<a name=\"cloudformation-stack-notification-check\"\
+    ></a>\n\nChecks whether your CloudFormation stacks are sending event notifications\
+    \ to an SNS topic\\. Optionally checks whether specified SNS topics are used\\\
+    . \n\n**Identifier:** CLOUDFORMATION\\_STACK\\_NOTIFICATION\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS\
+    \ GovCloud \\(US\\-West\\), Asia Pacific \\(Hong Kong\\), Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Europe \\(Paris\\), Europe \\\
+    (Stockholm\\), Middle East \\(Bahrain\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nsnsTopic1 \\(Optional\\)Type: String  \nSNS Topic ARN\\.\n\nsnsTopic2 \\(Optional\\\
+    )Type: String  \nSNS Topic ARN\\.\n\nsnsTopic3 \\(Optional\\)Type: String  \n\
+    SNS Topic ARN\\.\n\nsnsTopic4 \\(Optional\\)Type: String  \nSNS Topic ARN\\.\n\
+    \nsnsTopic5 \\(Optional\\)Type: String  \nSNS Topic ARN\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c53c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFORMATION_STACK_NOTIFICATION_CHECK
+  Name: cloudformation-stack-notification-check
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if Amazon CloudFront distributions are configured to capture
+    information from Amazon Simple Storage Service \(Amazon S3\) server access logs\.
+    This rule is NON\_COMPLIANT if a CloudFront distribution does not have logging
+    configured\.
+  File: cloudfront-accesslogs-enabled.md
+  FullDocumentation: "# cloudfront\\-accesslogs\\-enabled<a name=\"cloudfront-accesslogs-enabled\"\
+    ></a>\n\nChecks if Amazon CloudFront distributions are configured to capture information\
+    \ from Amazon Simple Storage Service \\(Amazon S3\\) server access logs\\. This\
+    \ rule is NON\\_COMPLIANT if a CloudFront distribution does not have logging configured\\\
+    . \n\n**Identifier:** CLOUDFRONT\\_ACCESSLOGS\\_ENABLED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** Only available in US East \\(N\\. Virginia\\) Region\n\
+    \n**Parameters:**\n\nS3BucketName \\(Optional\\)Type: String  \nThe name of the\
+    \ Amazon S3 bucket for storing server access logs\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c55c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_ACCESSLOGS_ENABLED
+  Name: cloudfront-accesslogs-enabled
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if Amazon CloudFront distributions are associated with either
+    WAF or WAFv2 web access control lists \(ACLs\)\. This rule is NON\_COMPLIANT if
+    a CloudFront distribution is not associated with a web ACL\.
+  File: cloudfront-associated-with-waf.md
+  FullDocumentation: "# cloudfront\\-associated\\-with\\-waf<a name=\"cloudfront-associated-with-waf\"\
+    ></a>\n\nChecks if Amazon CloudFront distributions are associated with either\
+    \ WAF or WAFv2 web access control lists \\(ACLs\\)\\. This rule is NON\\_COMPLIANT\
+    \ if a CloudFront distribution is not associated with a web ACL\\. \n\n**Identifier:**\
+    \ CLOUDFRONT\\_ASSOCIATED\\_WITH\\_WAF\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** Only available in US East \\(N\\. Virginia\\) Region\n\n**Parameters:**\n\
+    \nwafWebAclIds \\(Optional\\)Type: CSV  \nComma\\-separated list of web ACL IDs\
+    \ for WAF or web ACL Amazon Resource Names \\(ARNs\\) for WAFV2\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c57c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_ASSOCIATED_WITH_WAF
+  Name: cloudfront-associated-with-waf
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if the certificate associated with an Amazon CloudFront distribution
+    is the default Secure Sockets Layer \(SSL\) certificate\. This rule is NON\_COMPLIANT
+    if a CloudFront distribution uses the default SSL certificate\.
+  File: cloudfront-custom-ssl-certificate.md
+  FullDocumentation: "# cloudfront\\-custom\\-ssl\\-certificate<a name=\"cloudfront-custom-ssl-certificate\"\
+    ></a>\n\nChecks if the certificate associated with an Amazon CloudFront distribution\
+    \ is the default Secure Sockets Layer \\(SSL\\) certificate\\. This rule is NON\\\
+    _COMPLIANT if a CloudFront distribution uses the default SSL certificate\\. \n\
+    \n**Identifier:** CLOUDFRONT\\_CUSTOM\\_SSL\\_CERTIFICATE\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** Only available in US East \\(N\\. Virginia\\\
+    ) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7c59c15\"></a>\n\nTo create AWS Config managed rules with AWS CloudFormation\
+    \ templates, see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_CUSTOM_SSL_CERTIFICATE
+  Name: cloudfront-custom-ssl-certificate
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if an Amazon CloudFront distribution is configured to return
+    a specific object that is the default root object\. The rule is NON\_COMPLIANT
+    if Amazon CloudFront distribution does not have a default root object configured\.
+  File: cloudfront-default-root-object-configured.md
+  FullDocumentation: "# cloudfront\\-default\\-root\\-object\\-configured<a name=\"\
+    cloudfront-default-root-object-configured\"></a>\n\nChecks if an Amazon CloudFront\
+    \ distribution is configured to return a specific object that is the default root\
+    \ object\\. The rule is NON\\_COMPLIANT if Amazon CloudFront distribution does\
+    \ not have a default root object configured\\. \n\n**Identifier:** CLOUDFRONT\\\
+    _DEFAULT\\_ROOT\\_OBJECT\\_CONFIGURED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** Only available in US East \\(N\\. Virginia\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c61c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_DEFAULT_ROOT_OBJECT_CONFIGURED
+  Name: cloudfront-default-root-object-configured
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: "Checks if CloudFront distributions are using deprecated SSL protocols\
+    \ for HTTPS communication between CloudFront edge locations and custom origins\\\
+    . This rule is NON\\_COMPLIANT for a CloudFront distribution if any \u2018OriginSslProtocols\u2019\
+    \ includes \u2018SSLv3\u2019\\."
+  File: cloudfront-no-deprecated-ssl-protocols.md
+  FullDocumentation: "# cloudfront\\-no\\-deprecated\\-ssl\\-protocols<a name=\"cloudfront-no-deprecated-ssl-protocols\"\
+    ></a>\n\nChecks if CloudFront distributions are using deprecated SSL protocols\
+    \ for HTTPS communication between CloudFront edge locations and custom origins\\\
+    . This rule is NON\\_COMPLIANT for a CloudFront distribution if any \u2018OriginSslProtocols\u2019\
+    \ includes \u2018SSLv3\u2019\\. \n\n**Identifier:** CLOUDFRONT\\_NO\\_DEPRECATED\\\
+    _SSL\\_PROTOCOLS\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ Only available in US East \\(N\\. Virginia\\) Region\n\n**Parameters:**\n\n\
+    None  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c63c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_NO_DEPRECATED_SSL_PROTOCOLS
+  Name: cloudfront-no-deprecated-ssl-protocols
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if Amazon CloudFront distribution with S3 Origin type has Origin
+    Access Identity \(OAI\) configured\. The rule is NON\_COMPLIANT if the CloudFront
+    distribution is backed by S3 and any of S3 Origin type is not OAI configured\.
+    The rule is NON\_COMPLIANT if the origin is not an S3 bucket; the rule does not
+    return NOT\_APPLICABLE if the origin is not as S3 bucket\.
+  File: cloudfront-origin-access-identity-enabled.md
+  FullDocumentation: "# cloudfront\\-origin\\-access\\-identity\\-enabled<a name=\"\
+    cloudfront-origin-access-identity-enabled\"></a>\n\nChecks if Amazon CloudFront\
+    \ distribution with S3 Origin type has Origin Access Identity \\(OAI\\) configured\\\
+    . The rule is NON\\_COMPLIANT if the CloudFront distribution is backed by S3 and\
+    \ any of S3 Origin type is not OAI configured\\. The rule is NON\\_COMPLIANT if\
+    \ the origin is not an S3 bucket; the rule does not return NOT\\_APPLICABLE if\
+    \ the origin is not as S3 bucket\\.\n\n**Identifier:** CLOUDFRONT\\_ORIGIN\\_ACCESS\\\
+    _IDENTITY\\_ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**Only\
+    \ available in US East \\(N\\. Virginia\\) Region\n\n**Parameters:**\n\nNone \
+    \ \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c65c15\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED
+  Name: cloudfront-origin-access-identity-enabled
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks whether an origin group is configured for the distribution of
+    at least 2 origins in the origin group for Amazon CloudFront\. This rule is NON\_COMPLIANT
+    if there are no origin groups for the distribution\.
+  File: cloudfront-origin-failover-enabled.md
+  FullDocumentation: "# cloudfront\\-origin\\-failover\\-enabled<a name=\"cloudfront-origin-failover-enabled\"\
+    ></a>\n\nChecks whether an origin group is configured for the distribution of\
+    \ at least 2 origins in the origin group for Amazon CloudFront\\. This rule is\
+    \ NON\\_COMPLIANT if there are no origin groups for the distribution\\. \n\n**Identifier:**\
+    \ CLOUDFRONT\\_ORIGIN\\_FAILOVER\\_ENABLED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** Only available in US East \\(N\\. Virginia\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c67c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_ORIGIN_FAILOVER_ENABLED
+  Name: cloudfront-origin-failover-enabled
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if Amazon CloudFront distributions are using a custom SSL certificate
+    and are configured to use SNI to serve HTTPS requests\. This rule is NON\_COMPLIANT
+    if a custom SSL certificate is associated but the SSL support method is a dedicated
+    IP address\.
+  File: cloudfront-sni-enabled.md
+  FullDocumentation: "# cloudfront\\-sni\\-enabled<a name=\"cloudfront-sni-enabled\"\
+    ></a>\n\nChecks if Amazon CloudFront distributions are using a custom SSL certificate\
+    \ and are configured to use SNI to serve HTTPS requests\\. This rule is NON\\\
+    _COMPLIANT if a custom SSL certificate is associated but the SSL support method\
+    \ is a dedicated IP address\\. \n\n**Identifier:** CLOUDFRONT\\_SNI\\_ENABLED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** Only available in\
+    \ US East \\(N\\. Virginia\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c69c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_SNI_ENABLED
+  Name: cloudfront-sni-enabled
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: "Checks if Amazon CloudFront distributions are encrypting traffic to\
+    \ custom origins\\. The rule is NON\\_COMPLIANT if \u2018OriginProtocolPolicy\u2019\
+    \ is \u2018http\\-only\u2019 or if \u2018OriginProtocolPolicy\u2019 is \u2018\
+    match\\-viewer\u2019 and \u2018ViewerProtocolPolicy\u2019 is \u2018allow\\-all\u2019\
+    \\."
+  File: cloudfront-traffic-to-origin-encrypted.md
+  FullDocumentation: "# cloudfront\\-traffic\\-to\\-origin\\-encrypted<a name=\"cloudfront-traffic-to-origin-encrypted\"\
+    ></a>\n\nChecks if Amazon CloudFront distributions are encrypting traffic to custom\
+    \ origins\\. The rule is NON\\_COMPLIANT if \u2018OriginProtocolPolicy\u2019 is\
+    \ \u2018http\\-only\u2019 or if \u2018OriginProtocolPolicy\u2019 is \u2018match\\\
+    -viewer\u2019 and \u2018ViewerProtocolPolicy\u2019 is \u2018allow\\-all\u2019\\\
+    . \n\n**Identifier:** CLOUDFRONT\\_TRAFFIC\\_TO\\_ORIGIN\\_ENCRYPTED\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** Only available in US East \\\
+    (N\\. Virginia\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c71c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_TRAFFIC_TO_ORIGIN_ENCRYPTED
+  Name: cloudfront-traffic-to-origin-encrypted
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks whether your Amazon CloudFront distributions use HTTPS \(directly
+    or via a redirection\)\. The rule is NON\_COMPLIANT if the value of ViewerProtocolPolicy
+    is set to 'allow\-all' for the defaultCacheBehavior or for the cacheBehaviors\.
+  File: cloudfront-viewer-policy-https.md
+  FullDocumentation: "# cloudfront\\-viewer\\-policy\\-https<a name=\"cloudfront-viewer-policy-https\"\
+    ></a>\n\nChecks whether your Amazon CloudFront distributions use HTTPS \\(directly\
+    \ or via a redirection\\)\\. The rule is NON\\_COMPLIANT if the value of ViewerProtocolPolicy\
+    \ is set to 'allow\\-all' for the defaultCacheBehavior or for the cacheBehaviors\\\
+    . \n\n**Identifier:** CLOUDFRONT\\_VIEWER\\_POLICY\\_HTTPS\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** Only available in US East \\(N\\. Virginia\\\
+    ) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7c73c15\"></a>\n\nTo create AWS Config managed rules with AWS CloudFormation\
+    \ templates, see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDFRONT_VIEWER_POLICY_HTTPS
+  Name: cloudfront-viewer-policy-https
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if AWS CloudTrail is enabled in your AWS account\. Optionally,
+    you can specify which S3 bucket, SNS topic, and AWS CloudTrail ARN to use\. The
+    rule is NON\_COMPLIANT if AWS CloudTrail is not enabled\.
+  File: cloudtrail-enabled.md
+  FullDocumentation: "# cloudtrail\\-enabled<a name=\"cloudtrail-enabled\"></a>\n\n\
+    Checks if AWS CloudTrail is enabled in your AWS account\\. Optionally, you can\
+    \ specify which S3 bucket, SNS topic, and AWS CloudTrail ARN to use\\. The rule\
+    \ is NON\\_COMPLIANT if AWS CloudTrail is not enabled\\.\n\n**Identifier:** CLOUD\\\
+    _TRAIL\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported\
+    \ AWS regions\n\n**Parameters:**\n\ns3BucketName \\(Optional\\)Type: String  \n\
+    Name of S3 bucket for CloudTrail to deliver log files to\\.\n\nsnsTopicArn \\\
+    (Optional\\)Type: String  \nSNS topic ARN for CloudTrail to use for notifications\\\
+    .\n\ncloudWatchLogsLogGroupArn \\(Optional\\)Type: String  \nCloudWatch log group\
+    \ ARN for CloudTrail to send data to\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7c91c15\"></a>\n\nTo create AWS Config managed rules with AWS CloudFormation\
+    \ templates, see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUD_TRAIL_ENABLED
+  Name: cloudtrail-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks whether at least one AWS CloudTrail trail is logging Amazon
+    S3 data events for all S3 buckets\. The rule is NON\_COMPLIANT if trails log data
+    events for S3 buckets is not configured\.
+  File: cloudtrail-s3-dataevents-enabled.md
+  FullDocumentation: "# cloudtrail\\-s3\\-dataevents\\-enabled<a name=\"cloudtrail-s3-dataevents-enabled\"\
+    ></a>\n\nChecks whether at least one AWS CloudTrail trail is logging Amazon S3\
+    \ data events for all S3 buckets\\. The rule is NON\\_COMPLIANT if trails log\
+    \ data events for S3 buckets is not configured\\. \n\n**Identifier:** CLOUDTRAIL\\\
+    _S3\\_DATAEVENTS\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All\
+    \ supported AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\\
+    ) Region\n\n**Parameters:**\n\nS3BucketNames \\(Optional\\)Type: String  \nComma\\\
+    -separated list of S3 bucket names for which data events logging should be enabled\\\
+    . Default behavior checks for all S3 buckets\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7c75c15\"></a>\n\nTo create AWS Config managed rules with\
+    \ AWS CloudFormation templates, see [Creating AWS Config Managed Rules With AWS\
+    \ CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDTRAIL_S3_DATAEVENTS_ENABLED
+  Name: cloudtrail-s3-dataevents-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: 'Checks that there is at least one AWS CloudTrail trail defined with
+    security best practices\. This rule is COMPLIANT if there is at least one trail
+    that meets all of the following:
+
+    + records global service events
+
+    + is a multi\-region trail
+
+    + has Log file validation enabled
+
+    + encrypted with a KMS key
+
+    + records events for reads and writes
+
+    + records management events
+
+    + does not exclude any management events
+
+
+    This rule is NON\_COMPLIANT if no trails meet all of the criteria mentioned above\.'
+  File: cloudtrail-security-trail-enabled.md
+  FullDocumentation: "# cloudtrail\\-security\\-trail\\-enabled<a name=\"cloudtrail-security-trail-enabled\"\
+    ></a>\n\nChecks that there is at least one AWS CloudTrail trail defined with security\
+    \ best practices\\. This rule is COMPLIANT if there is at least one trail that\
+    \ meets all of the following:\n+ records global service events\n+ is a multi\\\
+    -region trail\n+ has Log file validation enabled\n+ encrypted with a KMS key\n\
+    + records events for reads and writes\n+ records management events\n+ does not\
+    \ exclude any management events\n\nThis rule is NON\\_COMPLIANT if no trails meet\
+    \ all of the criteria mentioned above\\.\n\n**Identifier:** CLOUDTRAIL\\_SECURITY\\\
+    _TRAIL\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c77c19\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDTRAIL_SECURITY_TRAIL_ENABLED
+  Name: cloudtrail-security-trail-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks whether CloudWatch alarms have at least one alarm action, one
+    INSUFFICIENT\_DATA action, or one OK action enabled\. Optionally, checks whether
+    any of the actions matches one of the specified ARNs\.
+  File: cloudwatch-alarm-action-check.md
+  FullDocumentation: "# cloudwatch\\-alarm\\-action\\-check<a name=\"cloudwatch-alarm-action-check\"\
+    ></a>\n\nChecks whether CloudWatch alarms have at least one alarm action, one\
+    \ INSUFFICIENT\\_DATA action, or one OK action enabled\\. Optionally, checks whether\
+    \ any of the actions matches one of the specified ARNs\\. \n\n**Identifier:**\
+    \ CLOUDWATCH\\_ALARM\\_ACTION\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nalarmActionRequiredType:\
+    \ StringDefault: true  \nAlarms have at least one action\\.\n\ninsufficientDataActionRequiredType:\
+    \ StringDefault: true  \nAlarms have at least one action when the alarm transitions\
+    \ to the INSUFFICIENT\\_DATA state from any other state\\.\n\nokActionRequiredType:\
+    \ StringDefault: false  \nAlarms have at least one action when the alarm transitions\
+    \ to an OK state from any other state\\.\n\naction1 \\(Optional\\)Type: String\
+    \  \nThe action to execute, specified as an ARN\\.\n\naction2 \\(Optional\\)Type:\
+    \ String  \nThe action to execute, specified as an ARN\\.\n\naction3 \\(Optional\\\
+    )Type: String  \nThe action to execute, specified as an ARN\\.\n\naction4 \\(Optional\\\
+    )Type: String  \nThe action to execute, specified as an ARN\\.\n\naction5 \\(Optional\\\
+    )Type: String  \nThe action to execute, specified as an ARN\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c79c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDWATCH_ALARM_ACTION_CHECK
+  Name: cloudwatch-alarm-action-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if Amazon CloudWatch alarms actions are in enabled state\. The
+    rule is NON\_COMPLIANT if the CloudWatch alarms actions are not in enabled state\.
+  File: cloudwatch-alarm-action-enabled-check.md
+  FullDocumentation: "# cloudwatch\\-alarm\\-action\\-enabled\\-check<a name=\"cloudwatch-alarm-action-enabled-check\"\
+    ></a>\n\nChecks if Amazon CloudWatch alarms actions are in enabled state\\. The\
+    \ rule is NON\\_COMPLIANT if the CloudWatch alarms actions are not in enabled\
+    \ state\\. \n\n**Identifier:** CLOUDWATCH\\_ALARM\\_ACTION\\_ENABLED\\_CHECK\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7c81c15\"></a>\n\nTo create AWS Config managed rules with AWS CloudFormation\
+    \ templates, see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDWATCH_ALARM_ACTION_ENABLED_CHECK
+  Name: cloudwatch-alarm-action-enabled-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks whether the specified resource type has a CloudWatch alarm for
+    the specified metric\. For resource type, you can specify EBS volumes, EC2 instances,
+    RDS clusters, or S3 buckets\.
+  File: cloudwatch-alarm-resource-check.md
+  FullDocumentation: "# cloudwatch\\-alarm\\-resource\\-check<a name=\"cloudwatch-alarm-resource-check\"\
+    ></a>\n\nChecks whether the specified resource type has a CloudWatch alarm for\
+    \ the specified metric\\. For resource type, you can specify EBS volumes, EC2\
+    \ instances, RDS clusters, or S3 buckets\\. \n\n**Identifier:** CLOUDWATCH\\_ALARM\\\
+    _RESOURCE\\_CHECK\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported\
+    \ AWS regions\n\n**Parameters:**\n\nresourceTypeType: String  \nAWS resource type\\\
+    . The value can be one of the following: AWS::EC2::Volume, AWS::EC2::Instance,\
+    \ AWS::RDS::DBCluster, or AWS::S3::Bucket\\.\n\nmetricNameType: String  \nThe\
+    \ name for the metric associated with the alarm \\(for example, 'CPUUtilization'\
+    \ for EC2 instances\\)\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c83c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDWATCH_ALARM_RESOURCE_CHECK
+  Name: cloudwatch-alarm-resource-check
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks whether CloudWatch alarms with the given metric name have the
+    specified settings\.
+  File: cloudwatch-alarm-settings-check.md
+  FullDocumentation: "# cloudwatch\\-alarm\\-settings\\-check<a name=\"cloudwatch-alarm-settings-check\"\
+    ></a>\n\nChecks whether CloudWatch alarms with the given metric name have the\
+    \ specified settings\\. \n\n**Identifier:** CLOUDWATCH\\_ALARM\\_SETTINGS\\_CHECK\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions\n\n**Parameters:**\n\nmetricNameType: String  \nThe name for the metric\
+    \ associated with the alarm\\.\n\nthreshold \\(Optional\\)Type: int  \nThe value\
+    \ against which the specified statistic is compared\\.\n\nevaluationPeriods \\\
+    (Optional\\)Type: int  \nThe number of periods over which data is compared to\
+    \ the specified threshold\\.\n\nperiod \\(Optional\\)Type: intDefault: 300  \n\
+    The period, in seconds, during which the specified statistic is applied\\.\n\n\
+    comparisonOperator \\(Optional\\)Type: String  \nThe operation for comparing the\
+    \ specified statistic and threshold \\(for example, 'GreaterThanThreshold'\\)\\\
+    .\n\nstatistic \\(Optional\\)Type: String  \nThe statistic for the metric associated\
+    \ with the alarm \\(for example, 'Average' or 'Sum'\\)\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c85c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDWATCH_ALARM_SETTINGS_CHECK
+  Name: cloudwatch-alarm-settings-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\) Region
+  Description: Checks if a log group in Amazon CloudWatch Logs is encrypted with a
+    AWS Key Management Service \(KMS\) managed Customer Master Keys \(CMK\)\. The
+    rule is NON\_COMPLIANT if no AWS KMS CMK is configured on the log groups\.
+  File: cloudwatch-log-group-encrypted.md
+  FullDocumentation: "# cloudwatch\\-log\\-group\\-encrypted<a name=\"cloudwatch-log-group-encrypted\"\
+    ></a>\n\nChecks if a log group in Amazon CloudWatch Logs is encrypted with a AWS\
+    \ Key Management Service \\(KMS\\) managed Customer Master Keys \\(CMK\\)\\. The\
+    \ rule is NON\\_COMPLIANT if no AWS KMS CMK is configured on the log groups\\\
+    .\n\n**Identifier:** CLOUDWATCH\\_LOG\\_GROUP\\_ENCRYPTED\n\n**Trigger type:**\
+    \ Periodic\n\n**AWS Region:** All supported AWS regions except China \\(Beijing\\\
+    ), China \\(Ningxia\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nKmsKeyId \\(Optional\\)Type: String  \nAmazon Resource Name\
+    \ \\(ARN\\) of AWS Key Management Service \\(KMS\\) key that is used to encrypt\
+    \ the CloudWatch Logs log group\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7c87c15\"></a>\n\nTo create AWS Config managed rules with AWS CloudFormation\
+    \ templates, see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CLOUDWATCH_LOG_GROUP_ENCRYPTED
+  Name: cloudwatch-log-group-encrypted
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: "Checks if key rotation is enabled for each key and matches to the\
+    \ key ID of the customer created AWS KMS key \\(KMS key\\)\\. The rule is COMPLIANT,\
+    \ if the key rotation is enabled for specific key object\\. The rule is not applicable\
+    \ to KMS keys that have imported key material\\.\n\n**Note**  \nThis rule only\
+    \ evaluates symmetric KMS keys and ignores asymmetric KMS keys\\."
+  File: cmk-backing-key-rotation-enabled.md
+  FullDocumentation: "# cmk\\-backing\\-key\\-rotation\\-enabled<a name=\"cmk-backing-key-rotation-enabled\"\
+    ></a>\n\nChecks if key rotation is enabled for each key and matches to the key\
+    \ ID of the customer created AWS KMS key \\(KMS key\\)\\. The rule is COMPLIANT,\
+    \ if the key rotation is enabled for specific key object\\. The rule is not applicable\
+    \ to KMS keys that have imported key material\\.\n\n**Note**  \nThis rule only\
+    \ evaluates symmetric KMS keys and ignores asymmetric KMS keys\\.\n\n**Identifier:**\
+    \ CMK\\_BACKING\\_KEY\\_ROTATION\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS\
+    \ Region:** All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7c97c17\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CMK_BACKING_KEY_ROTATION_ENABLED
+  Name: cmk-backing-key-rotation-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: "Checks if an AWS CodeBuild project has encryption enabled for all\
+    \ of its artifacts\\. The rule is NON\\_COMPLIANT if \u2018encryptionDisabled\u2019\
+    \ is set to \u2018true\u2019 for any primary or secondary \\(if present\\) artifact\
+    \ configurations\\."
+  File: codebuild-project-artifact-encryption.md
+  FullDocumentation: "# codebuild\\-project\\-artifact\\-encryption<a name=\"codebuild-project-artifact-encryption\"\
+    ></a>\n\nChecks if an AWS CodeBuild project has encryption enabled for all of\
+    \ its artifacts\\. The rule is NON\\_COMPLIANT if \u2018encryptionDisabled\u2019\
+    \ is set to \u2018true\u2019 for any primary or secondary \\(if present\\) artifact\
+    \ configurations\\. \n\n**Identifier:** CODEBUILD\\_PROJECT\\_ARTIFACT\\_ENCRYPTION\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\
+    \n## AWS CloudFormation template<a name=\"w76aac11c31c17b7c99c15\"></a>\n\nTo\
+    \ create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEBUILD_PROJECT_ARTIFACT_ENCRYPTION
+  Name: codebuild-project-artifact-encryption
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: "Checks if an AWS CodeBuild project environment has privileged mode\
+    \ enabled\\. The rule is NON\\_COMPLIANT for a CodeBuild project if \u2018privilegedMode\u2019\
+    \ is set to \u2018true\u2019\\."
+  File: codebuild-project-environment-privileged-check.md
+  FullDocumentation: "# codebuild\\-project\\-environment\\-privileged\\-check<a name=\"\
+    codebuild-project-environment-privileged-check\"></a>\n\nChecks if an AWS CodeBuild\
+    \ project environment has privileged mode enabled\\. The rule is NON\\_COMPLIANT\
+    \ for a CodeBuild project if \u2018privilegedMode\u2019 is set to \u2018true\u2019\
+    \\. \n\n**Identifier:** CODEBUILD\\_PROJECT\\_ENVIRONMENT\\_PRIVILEGED\\_CHECK\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nexemptedProjects\
+    \ \\(Optional\\)Type: CSV  \nComma\\-separated list of CodeBuild project names\
+    \ that are allowed to have \u2018privilegedMode\u2019 with value \u2018true\u2019\
+    \\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d101c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEBUILD_PROJECT_ENVIRONMENT_PRIVILEGED_CHECK
+  Name: codebuild-project-environment-privileged-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), Asia Pacific
+    \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether the project contains environment variables AWS\_ACCESS\_KEY\_ID
+    and AWS\_SECRET\_ACCESS\_KEY\. The rule is NON\_COMPLIANT when the project environment
+    variables contains plaintext credentials\.
+  File: codebuild-project-envvar-awscred-check.md
+  FullDocumentation: "# codebuild\\-project\\-envvar\\-awscred\\-check<a name=\"codebuild-project-envvar-awscred-check\"\
+    ></a>\n\nChecks whether the project contains environment variables AWS\\_ACCESS\\\
+    _KEY\\_ID and AWS\\_SECRET\\_ACCESS\\_KEY\\. The rule is NON\\_COMPLIANT when\
+    \ the project environment variables contains plaintext credentials\\. \n\n**Identifier:**\
+    \ CODEBUILD\\_PROJECT\\_ENVVAR\\_AWSCRED\\_CHECK\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except AWS GovCloud \\\
+    (US\\-East\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\\
+    (Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d103c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEBUILD_PROJECT_ENVVAR_AWSCRED_CHECK
+  Name: codebuild-project-envvar-awscred-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks if an AWS CodeBuild project environment has at least one log
+    option enabled\. The rule is NON\_COMPLIANT if 'logsConfig' is not present or
+    the status of all present log configurations is set to 'DISABLED'\.
+  File: codebuild-project-logging-enabled.md
+  FullDocumentation: "# codebuild\\-project\\-logging\\-enabled<a name=\"codebuild-project-logging-enabled\"\
+    ></a>\n\nChecks if an AWS CodeBuild project environment has at least one log option\
+    \ enabled\\. The rule is NON\\_COMPLIANT if 'logsConfig' is not present or the\
+    \ status of all present log configurations is set to 'DISABLED'\\. \n\n**Identifier:**\
+    \ CODEBUILD\\_PROJECT\\_LOGGING\\_ENABLED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\ns3BucketNames \\(Optional\\)Type: String  \nComma\\-separated\
+    \ list of Amazon S3 bucket names that logs should be sent to if S3 logs are configured\\\
+    .\n\ncloudWatchGroupNames \\(Optional\\)Type: String  \nComma\\-separated list\
+    \ of Amazon CloudWatch log group names that logs should be be sent to if CloudWatch\
+    \ logs are configured\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d105c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEBUILD_PROJECT_LOGGING_ENABLED
+  Name: codebuild-project-logging-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: "Checks if a AWS CodeBuild project configured with Amazon S3 Logs has\
+    \ encryption enabled for its logs\\. The rule is NON\\_COMPLIANT if \u2018encryptionDisabled\u2019\
+    \ is set to \u2018true\u2019 in a S3LogsConfig of a CodeBuild project\\."
+  File: codebuild-project-s3-logs-encrypted.md
+  FullDocumentation: "# codebuild\\-project\\-s3\\-logs\\-encrypted<a name=\"codebuild-project-s3-logs-encrypted\"\
+    ></a>\n\nChecks if a AWS CodeBuild project configured with Amazon S3 Logs has\
+    \ encryption enabled for its logs\\. The rule is NON\\_COMPLIANT if \u2018encryptionDisabled\u2019\
+    \ is set to \u2018true\u2019 in a S3LogsConfig of a CodeBuild project\\. \n\n\
+    **Identifier:** CODEBUILD\\_PROJECT\\_S3\\_LOGS\\_ENCRYPTED\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nexemptedProjects \\(Optional\\\
+    )Type: CSV  \nComma\\-separated list of CodeBuild project names that are allowed\
+    \ to output unencrypted logs\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d107c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEBUILD_PROJECT_S3_LOGS_ENCRYPTED
+  Name: codebuild-project-s3-logs-encrypted
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), Asia Pacific
+    \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether the GitHub or Bitbucket source repository URL contains
+    either personal access tokens or user name and password\. The rule is complaint
+    with the usage of OAuth to grant authorization for accessing GitHub or Bitbucket
+    repositories\.
+  File: codebuild-project-source-repo-url-check.md
+  FullDocumentation: "# codebuild\\-project\\-source\\-repo\\-url\\-check<a name=\"\
+    codebuild-project-source-repo-url-check\"></a>\n\nChecks whether the GitHub or\
+    \ Bitbucket source repository URL contains either personal access tokens or user\
+    \ name and password\\. The rule is complaint with the usage of OAuth to grant\
+    \ authorization for accessing GitHub or Bitbucket repositories\\. \n\n**Identifier:**\
+    \ CODEBUILD\\_PROJECT\\_SOURCE\\_REPO\\_URL\\_CHECK\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except AWS GovCloud \\\
+    (US\\-East\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\\
+    (Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d109c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEBUILD_PROJECT_SOURCE_REPO_URL_CHECK
+  Name: codebuild-project-source-repo-url-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if the deployment group is configured with automatic deployment
+    rollback and deployment monitoring with alarms attached\. The rule is NON\_COMPLIANT
+    if AutoRollbackConfiguration or AlarmConfiguration has not been configured or
+    is not enabled\.
+  File: codedeploy-auto-rollback-monitor-enabled.md
+  FullDocumentation: "# codedeploy\\-auto\\-rollback\\-monitor\\-enabled<a name=\"\
+    codedeploy-auto-rollback-monitor-enabled\"></a>\n\nChecks if the deployment group\
+    \ is configured with automatic deployment rollback and deployment monitoring with\
+    \ alarms attached\\. The rule is NON\\_COMPLIANT if AutoRollbackConfiguration\
+    \ or AlarmConfiguration has not been configured or is not enabled\\. \n\n**Identifier:**\
+    \ CODEDEPLOY\\_AUTO\\_ROLLBACK\\_MONITOR\\_ENABLED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    None  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d111c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEDEPLOY_AUTO_ROLLBACK_MONITOR_ENABLED
+  Name: codedeploy-auto-rollback-monitor-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if the deployment group for EC2/On\-Premises Compute Platform
+    is configured with a minimum healthy hosts fleet percentage or host count greater
+    than or equal to the input threshold\. The rule is NON\_COMPLIANT if either is
+    below the threshold\.
+  File: codedeploy-ec2-minimum-healthy-hosts-configured.md
+  FullDocumentation: "# codedeploy\\-ec2\\-minimum\\-healthy\\-hosts\\-configured<a\
+    \ name=\"codedeploy-ec2-minimum-healthy-hosts-configured\"></a>\n\nChecks if the\
+    \ deployment group for EC2/On\\-Premises Compute Platform is configured with a\
+    \ minimum healthy hosts fleet percentage or host count greater than or equal to\
+    \ the input threshold\\. The rule is NON\\_COMPLIANT if either is below the threshold\\\
+    . \n\n**Identifier:** CODEDEPLOY\\_EC2\\_MINIMUM\\_HEALTHY\\_HOSTS\\_CONFIGURED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions\n\n**Parameters:**\n\nminimumHealthyHostsFleetPercent \\(Optional\\\
+    )Type: intDefault: 66  \nMinimum percentage of healthy hosts fleet during deployment\\\
+    . Default value is set to 66 percent\\.\n\nminimumHealthyHostsHostCount \\(Optional\\\
+    )Type: intDefault: 1  \nMinimum number of healthy hosts in fleet during deployment\\\
+    . Default value is set to 1\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d113c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEDEPLOY_EC2_MINIMUM_HEALTHY_HOSTS_CONFIGURED
+  Name: codedeploy-ec2-minimum-healthy-hosts-configured
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if the deployment group for Lambda Compute Platform is not using
+    the default deployment configuration\. The rule is NON\_COMPLIANT if the deployment
+    group is using the deployment configuration 'CodeDeployDefault\.LambdaAllAtOnce'\.
+  File: codedeploy-lambda-allatonce-traffic-shift-disabled.md
+  FullDocumentation: "# codedeploy\\-lambda\\-allatonce\\-traffic\\-shift\\-disabled<a\
+    \ name=\"codedeploy-lambda-allatonce-traffic-shift-disabled\"></a>\n\nChecks if\
+    \ the deployment group for Lambda Compute Platform is not using the default deployment\
+    \ configuration\\. The rule is NON\\_COMPLIANT if the deployment group is using\
+    \ the deployment configuration 'CodeDeployDefault\\.LambdaAllAtOnce'\\. \n\n**Identifier:**\
+    \ CODEDEPLOY\\_LAMBDA\\_ALLATONCE\\_TRAFFIC\\_SHIFT\\_DISABLED\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d115c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEDEPLOY_LAMBDA_ALLATONCE_TRAFFIC_SHIFT_DISABLED
+  Name: codedeploy-lambda-allatonce-traffic-shift-disabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Hong Kong\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Europe \(Stockholm\),
+    Middle East \(Bahrain\), Africa \(Cape Town\) Region
+  Description: Checks whether the first deployment stage of the AWS Codepipeline performs
+    more than one deployment\. Optionally checks if each of the subsequent remaining
+    stages deploy to more than the specified number of deployments \(`deploymentLimit`\)\.
+  File: codepipeline-deployment-count-check.md
+  FullDocumentation: "# codepipeline\\-deployment\\-count\\-check<a name=\"codepipeline-deployment-count-check\"\
+    ></a>\n\nChecks whether the first deployment stage of the AWS Codepipeline performs\
+    \ more than one deployment\\. Optionally checks if each of the subsequent remaining\
+    \ stages deploy to more than the specified number of deployments \\(`deploymentLimit`\\\
+    )\\. \n\n**Identifier:** CODEPIPELINE\\_DEPLOYMENT\\_COUNT\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS\
+    \ GovCloud \\(US\\-West\\), Asia Pacific \\(Hong Kong\\), Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Europe \\(Stockholm\\), Middle\
+    \ East \\(Bahrain\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\ndeploymentLimit\
+    \ \\(Optional\\)Type: int  \nThe maximum number of deployments each stage can\
+    \ perform\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d117c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEPIPELINE_DEPLOYMENT_COUNT_CHECK
+  Name: codepipeline-deployment-count-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Hong Kong\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Europe \(Stockholm\),
+    Middle East \(Bahrain\), Africa \(Cape Town\) Region
+  Description: 'Checks if each stage in the AWS CodePipeline deploys to more than
+    N times the number of the regions the AWS CodePipeline has deployed in all the
+    previous combined stages, where N is the region fanout number\. The first deployment
+    stage can deploy to a maximum of one region and the second deployment stage can
+    deploy to a maximum number specified in the `regionFanoutFactor`\. If you do not
+    provide a `regionFanoutFactor`, by default the value is three\. For example: If
+    1st deployment stage deploys to one region and 2nd deployment stage deploys to
+    three regions, 3rd deployment stage can deploy to 12 regions, that is, sum of
+    previous stages multiplied by the region fanout \(three\) number\. The rule is
+    NON\_COMPLIANT if the deployment is in more than one region in 1st stage or three
+    regions in 2nd stage or 12 regions in 3rd stage\.'
+  File: codepipeline-region-fanout-check.md
+  FullDocumentation: "# codepipeline\\-region\\-fanout\\-check<a name=\"codepipeline-region-fanout-check\"\
+    ></a>\n\nChecks if each stage in the AWS CodePipeline deploys to more than N times\
+    \ the number of the regions the AWS CodePipeline has deployed in all the previous\
+    \ combined stages, where N is the region fanout number\\. The first deployment\
+    \ stage can deploy to a maximum of one region and the second deployment stage\
+    \ can deploy to a maximum number specified in the `regionFanoutFactor`\\. If you\
+    \ do not provide a `regionFanoutFactor`, by default the value is three\\. For\
+    \ example: If 1st deployment stage deploys to one region and 2nd deployment stage\
+    \ deploys to three regions, 3rd deployment stage can deploy to 12 regions, that\
+    \ is, sum of previous stages multiplied by the region fanout \\(three\\) number\\\
+    . The rule is NON\\_COMPLIANT if the deployment is in more than one region in\
+    \ 1st stage or three regions in 2nd stage or 12 regions in 3rd stage\\.\n\n**Identifier:**\
+    \ CODEPIPELINE\\_REGION\\_FANOUT\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except China \\(Beijing\\), China\
+    \ \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Hong Kong\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\\
+    ), Europe \\(Milan\\), Europe \\(Stockholm\\), Middle East \\(Bahrain\\), Africa\
+    \ \\(Cape Town\\) Region\n\n**Parameters:**\n\nregionFanoutFactor \\(Optional\\\
+    )Type: intDefault: 3  \nThe number of regions the AWS CodePipeline has deployed\
+    \ to in all previous stages is the acceptable number of regions any stage can\
+    \ deploy to\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d119c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CODEPIPELINE_REGION_FANOUT_CHECK
+  Name: codepipeline-region-fanout-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: "Checks whether Amazon CloudWatch LogGroup retention period is set\
+    \ to specific number of days\\. The rule is NON\\_COMPLIANT if the retention period\
+    \ for the log group is less than the MinRetentionTime parameter\\. \n\n**Note**\
+    \  \nIf the retention setting is \"Never expire\" for a log group, the rule is\
+    \ marked as COMPLIANT\\."
+  File: cw-loggroup-retention-period-check.md
+  FullDocumentation: "# cw\\-loggroup\\-retention\\-period\\-check<a name=\"cw-loggroup-retention-period-check\"\
+    ></a>\n\nChecks whether Amazon CloudWatch LogGroup retention period is set to\
+    \ specific number of days\\. The rule is NON\\_COMPLIANT if the retention period\
+    \ for the log group is less than the MinRetentionTime parameter\\. \n\n**Note**\
+    \  \nIf the retention setting is \"Never expire\" for a log group, the rule is\
+    \ marked as COMPLIANT\\.\n\n**Identifier:** CW\\_LOGGROUP\\_RETENTION\\_PERIOD\\\
+    _CHECK\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions\
+    \ except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\
+    \nLogGroupNames \\(Optional\\)Type: CSV  \nA comma\\-separated list of Log Group\
+    \ names to check the retention period\\.\n\nMinRetentionTime \\(Optional\\)Type:\
+    \ int  \nSpecify the retention time\\. Valid values are: 1, 3, 5, 7, 14, 30, 60,\
+    \ 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653\\. The default retention\
+    \ period is 365 days\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d121c17\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: CW_LOGGROUP_RETENTION_PERIOD_CHECK
+  Name: cw-loggroup-retention-period-check
+  TriggerType: Periodic
+- AWSRegion: Only available in Asia Pacific \(Mumbai\), Europe \(Paris\), US East
+    \(Ohio\), Europe \(Ireland\), Europe \(Frankfurt\), South America \(Sao Paulo\),
+    US East \(N\. Virginia\), Europe \(London\), Asia Pacific \(Tokyo\), US West \(Oregon\),
+    US West \(N\. California\), Asia Pacific \(Singapore\), Asia Pacific \(Sydney\)
+    Region
+  Description: Checks that Amazon DynamoDB Accelerator \(DAX\) clusters are encrypted\.
+    The rule is NON\_COMPLIANT if a DAX cluster is not encrypted
+  File: dax-encryption-enabled.md
+  FullDocumentation: "# dax\\-encryption\\-enabled<a name=\"dax-encryption-enabled\"\
+    ></a>\n\nChecks that Amazon DynamoDB Accelerator \\(DAX\\) clusters are encrypted\\\
+    . The rule is NON\\_COMPLIANT if a DAX cluster is not encrypted \n\n**Identifier:**\
+    \ DAX\\_ENCRYPTION\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:**\
+    \ Only available in Asia Pacific \\(Mumbai\\), Europe \\(Paris\\), US East \\\
+    (Ohio\\), Europe \\(Ireland\\), Europe \\(Frankfurt\\), South America \\(Sao Paulo\\\
+    ), US East \\(N\\. Virginia\\), Europe \\(London\\), Asia Pacific \\(Tokyo\\),\
+    \ US West \\(Oregon\\), US West \\(N\\. California\\), Asia Pacific \\(Singapore\\\
+    ), Asia Pacific \\(Sydney\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d123c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DAX_ENCRYPTION_ENABLED
+  Name: dax-encryption-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks if RDS DB instances have backups enabled\. Optionally, the rule
+    checks the backup retention period and the backup window\.
+  File: db-instance-backup-enabled.md
+  FullDocumentation: "# db\\-instance\\-backup\\-enabled<a name=\"db-instance-backup-enabled\"\
+    ></a>\n\nChecks if RDS DB instances have backups enabled\\. Optionally, the rule\
+    \ checks the backup retention period and the backup window\\.\n\n**Identifier:**\
+    \ DB\\_INSTANCE\\_BACKUP\\_ENABLED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nbackupRetentionPeriod\
+    \ \\(Optional\\)Type: int  \nRetention period for backups\\.\n\nbackupRetentionMinimum\
+    \ \\(Optional\\)Type: int  \nMinimum retention period for backups\\.\n\npreferredBackupWindow\
+    \ \\(Optional\\)Type: String  \nTime range in which backups are created\\.\n\n\
+    checkReadReplicas \\(Optional\\)Type: boolean  \nChecks whether RDS DB instances\
+    \ have backups enabled for read replicas\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d125c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DB_INSTANCE_BACKUP_ENABLED
+  Name: db-instance-backup-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks instances for specified tenancy\. Specify AMI IDs to check instances
+    that are launched from those AMIs or specify host IDs to check whether instances
+    are launched on those Dedicated Hosts\. Separate multiple ID values with commas\.
+  File: desired-instance-tenancy.md
+  FullDocumentation: "# desired\\-instance\\-tenancy<a name=\"desired-instance-tenancy\"\
+    ></a>\n\nChecks instances for specified tenancy\\. Specify AMI IDs to check instances\
+    \ that are launched from those AMIs or specify host IDs to check whether instances\
+    \ are launched on those Dedicated Hosts\\. Separate multiple ID values with commas\\\
+    .\n\n**Identifier:** DESIRED\\_INSTANCE\\_TENANCY\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    tenancyType: String  \nDesired tenancy of the instances\\. Valid values are DEDICATED,\
+    \ HOST and DEFAULT\\.\n\nimageId \\(Optional\\)Type: CSV  \nThe rule evaluates\
+    \ instances launched only from AMIs with the specified IDs\\. Separate multiple\
+    \ AMI IDs with commas\\.\n\nhostId \\(Optional\\)Type: CSV  \nThe IDs of the EC2\
+    \ Dedicated Hosts on which the instances are meant to be launched\\. Separate\
+    \ multiple Host IDs with commas\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d127c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: DESIRED_INSTANCE_TENANCY
+  Name: desired-instance-tenancy
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: 'Checks whether your EC2 instances are of the specified instance types\.
+
+
+    For a list of supported Amazon EC2 instance types, see [Instance Types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
+    in the *Amazon EC2 User Guide for Linux Instances*\.'
+  File: desired-instance-type.md
+  FullDocumentation: "# desired\\-instance\\-type<a name=\"desired-instance-type\"\
+    ></a>\n\nChecks whether your EC2 instances are of the specified instance types\\\
+    .\n\nFor a list of supported Amazon EC2 instance types, see [Instance Types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)\
+    \ in the *Amazon EC2 User Guide for Linux Instances*\\.\n\n**Identifier:** DESIRED\\\
+    _INSTANCE\\_TYPE\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions\n\n**Parameters:**\n\ninstanceTypeType: CSV  \n Comma\\\
+    -separated list of EC2 instance types \\(for example, \"t2\\.small, m4\\.large,\
+    \ i2\\.xlarge\"\\)\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d129c17\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DESIRED_INSTANCE_TYPE
+  Name: desired-instance-type
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether AWS Database Migration Service replication instances
+    are public\. The rule is NON\_COMPLIANT if PubliclyAccessible field is True\.
+  File: dms-replication-not-public.md
+  FullDocumentation: "# dms\\-replication\\-not\\-public<a name=\"dms-replication-not-public\"\
+    ></a>\n\nChecks whether AWS Database Migration Service replication instances are\
+    \ public\\. The rule is NON\\_COMPLIANT if PubliclyAccessible field is True\\\
+    . \n\n**Identifier:** DMS\\_REPLICATION\\_NOT\\_PUBLIC\n\n**Trigger type:** Periodic\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d131c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DMS_REPLICATION_NOT_PUBLIC
+  Name: dms-replication-not-public
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), AWS GovCloud
+    \(US\-West\) Region
+  Description: Checks if Auto Scaling or On\-Demand is enabled on your DynamoDB tables
+    and/or global secondary indexes\. Optionally you can set the read and write capacity
+    units for the table or global secondary index\.
+  File: dynamodb-autoscaling-enabled.md
+  FullDocumentation: "# dynamodb\\-autoscaling\\-enabled<a name=\"dynamodb-autoscaling-enabled\"\
+    ></a>\n\nChecks if Auto Scaling or On\\-Demand is enabled on your DynamoDB tables\
+    \ and/or global secondary indexes\\. Optionally you can set the read and write\
+    \ capacity units for the table or global secondary index\\.\n\n**Identifier:**\
+    \ DYNAMODB\\_AUTOSCALING\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:**\
+    \ All supported AWS regions except AWS GovCloud \\(US\\-East\\), AWS GovCloud\
+    \ \\(US\\-West\\) Region\n\n**Parameters:**\n\nminProvisionedReadCapacity \\(Optional\\\
+    )Type: int  \nThe minimum number of units that should be provisioned with read\
+    \ capacity in the Auto Scaling group\\.\n\nmaxProvisionedReadCapacity \\(Optional\\\
+    )Type: int  \nThe minimum number of units that should be provisioned with write\
+    \ capacity in the Auto Scaling group\\.\n\ntargetReadUtilization \\(Optional\\\
+    )Type: double  \nThe maximum number of units that should be provisioned with read\
+    \ capacity in the Auto Scaling group\\.\n\nminProvisionedWriteCapacity \\(Optional\\\
+    )Type: int  \nThe maximum number of units that should be provisioned with write\
+    \ capacity in the Auto Scaling group\\.\n\nmaxProvisionedWriteCapacity \\(Optional\\\
+    )Type: int  \nThe target utilization percentage for read capacity\\. Target utilization\
+    \ is expressed in terms of the ratio of consumed capacity to provisioned capacity\\\
+    .\n\ntargetWriteUtilization \\(Optional\\)Type: double  \nThe target utilization\
+    \ percentage for write capacity\\. Target utilization is expressed in terms of\
+    \ the ratio of consumed capacity to provisioned capacity\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d133c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DYNAMODB_AUTOSCALING_ENABLED
+  Name: dynamodb-autoscaling-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), AWS GovCloud
+    \(US\-West\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks whether Amazon DynamoDB table is present in AWS Backup Plans\.
+    The rule is NON\_COMPLIANT if Amazon DynamoDB tables are not present in any AWS
+    Backup plan\.
+  File: dynamodb-in-backup-plan.md
+  FullDocumentation: "# dynamodb\\-in\\-backup\\-plan<a name=\"dynamodb-in-backup-plan\"\
+    ></a>\n\nChecks whether Amazon DynamoDB table is present in AWS Backup Plans\\\
+    . The rule is NON\\_COMPLIANT if Amazon DynamoDB tables are not present in any\
+    \ AWS Backup plan\\. \n\n**Identifier:** DYNAMODB\\_IN\\_BACKUP\\_PLAN\n\n**Trigger\
+    \ type:** Periodic\n\n**AWS Region:** All supported AWS regions except AWS GovCloud\
+    \ \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d135c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DYNAMODB_IN_BACKUP_PLAN
+  Name: dynamodb-in-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks that point in time recovery \(PITR\) is enabled for Amazon DynamoDB
+    tables\. The rule is NON\_COMPLIANT if point in time recovery is not enabled for
+    Amazon DynamoDB tables\.
+  File: dynamodb-pitr-enabled.md
+  FullDocumentation: "# dynamodb\\-pitr\\-enabled<a name=\"dynamodb-pitr-enabled\"\
+    ></a>\n\nChecks that point in time recovery \\(PITR\\) is enabled for Amazon DynamoDB\
+    \ tables\\. The rule is NON\\_COMPLIANT if point in time recovery is not enabled\
+    \ for Amazon DynamoDB tables\\.\n\n**Identifier:** DYNAMODB\\_PITR\\_ENABLED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d137c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DYNAMODB_PITR_ENABLED
+  Name: dynamodb-pitr-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon DynamoDB tables are protected by a backup plan\. The
+    rule is NON\_COMPLIANT if the DynamoDB Table is not covered by a backup plan\.
+  File: dynamodb-resources-protected-by-backup-plan.md
+  FullDocumentation: "# dynamodb\\-resources\\-protected\\-by\\-backup\\-plan<a name=\"\
+    dynamodb-resources-protected-by-backup-plan\"></a>\n\nChecks if Amazon DynamoDB\
+    \ tables are protected by a backup plan\\. The rule is NON\\_COMPLIANT if the\
+    \ DynamoDB Table is not covered by a backup plan\\. \n\n**Identifier:** DYNAMODB\\\
+    _RESOURCES\\_PROTECTED\\_BY\\_BACKUP\\_PLAN\n\n**Trigger type:** Periodic\n\n\
+    **AWS Region:** All supported AWS regions except Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nresourceTags\
+    \ \\(Optional\\)Type: String  \nTags for DynamoDB tables for the rule to check,\
+    \ in JSON format\\.\n\nresourceId \\(Optional\\)Type: String  \nName of DynamoDB\
+    \ table for the rule to check\\.\n\ncrossRegionList \\(Optional\\)Type: String\
+    \  \nComma\\-separated list of destination regions for the cross\\-region backup\
+    \ copy to be kept\n\ncrossAccountList \\(Optional\\)Type: String  \nComma\\-separated\
+    \ list of destination accounts for cross\\-account backup copy to be kept\n\n\
+    maxRetentionDays \\(Optional\\)Type: int  \nThe maximum retention period in days\
+    \ for the Backup Vault Lock\n\nminRetentionDays \\(Optional\\)Type: int  \nThe\
+    \ minimum retention period in days for the Backup Vault Lock\n\nbackupVaultLockCheck\
+    \ \\(Optional\\)Type: String  \nAccepted values: 'True' or 'False'\\. Enter 'True'\
+    \ for the rule to check if the resource is backed up in a locked vault\n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d139c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DYNAMODB_RESOURCES_PROTECTED_BY_BACKUP_PLAN
+  Name: dynamodb-resources-protected-by-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks if Amazon DynamoDB table is encrypted with AWS Key Management
+    Service \(KMS\)\. The rule is NON\_COMPLIANT if Amazon DynamoDB table is not encrypted
+    with AWS KMS\. The rule is also NON\_COMPLIANT if the encrypted AWS KMS key is
+    not present in `kmsKeyArns` input parameter\.
+  File: dynamodb-table-encrypted-kms.md
+  FullDocumentation: "# dynamodb\\-table\\-encrypted\\-kms<a name=\"dynamodb-table-encrypted-kms\"\
+    ></a>\n\nChecks if Amazon DynamoDB table is encrypted with AWS Key Management\
+    \ Service \\(KMS\\)\\. The rule is NON\\_COMPLIANT if Amazon DynamoDB table is\
+    \ not encrypted with AWS KMS\\. The rule is also NON\\_COMPLIANT if the encrypted\
+    \ AWS KMS key is not present in `kmsKeyArns` input parameter\\.\n\n**Identifier:**\
+    \ DYNAMODB\\_TABLE\\_ENCRYPTED\\_KMS\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nkmsKeyArns \\(Optional\\\
+    )Type: CSV  \nComma separated list of AWS KMS key ARNs allowed for encrypting\
+    \ Amazon DynamoDB Tables\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d141c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DYNAMODB_TABLE_ENCRYPTED_KMS
+  Name: dynamodb-table-encrypted-kms
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Ningxia\), Asia Pacific \(Hong
+    Kong\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Europe
+    \(Stockholm\), Middle East \(Bahrain\), Africa \(Cape Town\) Region
+  Description: Checks if the Amazon DynamoDB tables are encrypted and checks their
+    status\. The rule is COMPLIANT if the status is enabled or enabling\.
+  File: dynamodb-table-encryption-enabled.md
+  FullDocumentation: "# dynamodb\\-table\\-encryption\\-enabled<a name=\"dynamodb-table-encryption-enabled\"\
+    ></a>\n\nChecks if the Amazon DynamoDB tables are encrypted and checks their status\\\
+    . The rule is COMPLIANT if the status is enabled or enabling\\.\n\n**Identifier:**\
+    \ DYNAMODB\\_TABLE\\_ENCRYPTION\\_ENABLED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except China \\(Ningxia\\), Asia Pacific\
+    \ \\(Hong Kong\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\), Europe \\(Stockholm\\), Middle East \\(Bahrain\\), Africa \\(Cape\
+    \ Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d143c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DYNAMODB_TABLE_ENCRYPTION_ENABLED
+  Name: dynamodb-table-encryption-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if provisioned DynamoDB throughput is approaching the maximum
+    limit for your account\. By default, the rule checks if provisioned throughput
+    exceeds a threshold of 80 percent of your account limits\.
+  File: dynamodb-throughput-limit-check.md
+  FullDocumentation: "# dynamodb\\-throughput\\-limit\\-check<a name=\"dynamodb-throughput-limit-check\"\
+    ></a>\n\nChecks if provisioned DynamoDB throughput is approaching the maximum\
+    \ limit for your account\\. By default, the rule checks if provisioned throughput\
+    \ exceeds a threshold of 80 percent of your account limits\\.\n\n**Identifier:**\
+    \ DYNAMODB\\_THROUGHPUT\\_LIMIT\\_CHECK\n\n**Trigger type:** Periodic\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \naccountRCUThresholdPercentage \\(Optional\\)Type: intDefault: 80  \nPercentage\
+    \ of provisioned read capacity units for your account\\. When this value is reached,\
+    \ the rule is marked as NON\\_COMPLIANT\\.\n\naccountWCUThresholdPercentage \\\
+    (Optional\\)Type: intDefault: 80  \nPercentage of provisioned write capacity units\
+    \ for your account\\. When this value is reached, the rule is marked as NON\\\
+    _COMPLIANT\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d145c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: DYNAMODB_THROUGHPUT_LIMIT_CHECK
+  Name: dynamodb-throughput-limit-check
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), AWS GovCloud
+    \(US\-West\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Check if Amazon Elastic Block Store \(Amazon EBS\) volumes are added
+    in backup plans of AWS Backup\. The rule is NON\_COMPLIANT if Amazon EBS volumes
+    are not included in backup plans\.
+  File: ebs-in-backup-plan.md
+  FullDocumentation: "# ebs\\-in\\-backup\\-plan<a name=\"ebs-in-backup-plan\"></a>\n\
+    \nCheck if Amazon Elastic Block Store \\(Amazon EBS\\) volumes are added in backup\
+    \ plans of AWS Backup\\. The rule is NON\\_COMPLIANT if Amazon EBS volumes are\
+    \ not included in backup plans\\. \n\n**Identifier:** EBS\\_IN\\_BACKUP\\_PLAN\n\
+    \n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions except\
+    \ AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\\
+    (Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\\
+    ) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d147c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: EBS_IN_BACKUP_PLAN
+  Name: ebs-in-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks whether EBS optimization is enabled for your EC2 instances that
+    can be EBS\-optimized\. The rule is NON\_COMPLIANT if EBS optimization is not
+    enabled for an EC2 instance that can be EBS\-optimized\.
+  File: ebs-optimized-instance.md
+  FullDocumentation: "# ebs\\-optimized\\-instance<a name=\"ebs-optimized-instance\"\
+    ></a>\n\nChecks whether EBS optimization is enabled for your EC2 instances that\
+    \ can be EBS\\-optimized\\. The rule is NON\\_COMPLIANT if EBS optimization is\
+    \ not enabled for an EC2 instance that can be EBS\\-optimized\\.\n\n**Identifier:**\
+    \ EBS\\_OPTIMIZED\\_INSTANCE\n\n**Trigger type:** Configuration changes\n\n**AWS\
+    \ Region:** All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d149c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EBS_OPTIMIZED_INSTANCE
+  Name: ebs-optimized-instance
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon Elastic Block Store \(Amazon EBS\) volumes are protected
+    by a backup plan\. The rule is NON\_COMPLIANT if the Amazon EBS volume is not
+    covered by a backup plan\.
+  File: ebs-resources-protected-by-backup-plan.md
+  FullDocumentation: "# ebs\\-resources\\-protected\\-by\\-backup\\-plan<a name=\"\
+    ebs-resources-protected-by-backup-plan\"></a>\n\nChecks if Amazon Elastic Block\
+    \ Store \\(Amazon EBS\\) volumes are protected by a backup plan\\. The rule is\
+    \ NON\\_COMPLIANT if the Amazon EBS volume is not covered by a backup plan\\.\
+    \ \n\n**Identifier:** EBS\\_RESOURCES\\_PROTECTED\\_BY\\_BACKUP\\_PLAN\n\n**Trigger\
+    \ type:** Periodic\n\n**AWS Region:** All supported AWS regions except Asia Pacific\
+    \ \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nresourceTags \\(Optional\\)Type: String  \nTags for Amazon EBS volumes for the\
+    \ rule to check, in JSON format `{\"tagkey\" : \"tagValue\"}`\\.\n\nresourceId\
+    \ \\(Optional\\)Type: String  \nID of Amazon EBS volume for the rule to check\\\
+    .\n\ncrossRegionList \\(Optional\\)Type: String  \nComma\\-separated list of destination\
+    \ regions for the cross\\-region backup copy to be kept\n\ncrossAccountList \\\
+    (Optional\\)Type: String  \nComma\\-separated list of destination accounts for\
+    \ cross\\-account backup copy to be kept\n\nmaxRetentionDays \\(Optional\\)Type:\
+    \ int  \nThe maximum retention period in days for the Backup Vault Lock\n\nminRetentionDays\
+    \ \\(Optional\\)Type: int  \nThe minimum retention period in days for the Backup\
+    \ Vault Lock\n\nbackupVaultLockCheck \\(Optional\\)Type: String  \nAccepted values:\
+    \ 'True' or 'False'\\. Enter 'True' for the rule to check if the resource is backed\
+    \ up in a locked vault\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d151c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EBS_RESOURCES_PROTECTED_BY_BACKUP_PLAN
+  Name: ebs-resources-protected-by-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks whether Amazon Elastic Block Store \(Amazon EBS\) snapshots
+    are not publicly restorable\. The rule is NON\_COMPLIANT if one or more snapshots
+    with RestorableByUserIds field are set to all, that is, Amazon EBS snapshots are
+    public\.
+  File: ebs-snapshot-public-restorable-check.md
+  FullDocumentation: "# ebs\\-snapshot\\-public\\-restorable\\-check<a name=\"ebs-snapshot-public-restorable-check\"\
+    ></a>\n\nChecks whether Amazon Elastic Block Store \\(Amazon EBS\\) snapshots\
+    \ are not publicly restorable\\. The rule is NON\\_COMPLIANT if one or more snapshots\
+    \ with RestorableByUserIds field are set to all, that is, Amazon EBS snapshots\
+    \ are public\\. \n\n**Identifier:** EBS\\_SNAPSHOT\\_PUBLIC\\_RESTORABLE\\_CHECK\n\
+    \n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions except\
+    \ Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d153c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EBS_SNAPSHOT_PUBLIC_RESTORABLE_CHECK
+  Name: ebs-snapshot-public-restorable-check
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Check that Amazon Elastic Block Store \(EBS\) encryption is enabled
+    by default\. The rule is NON\_COMPLIANT if the encryption is not enabled\.
+  File: ec2-ebs-encryption-by-default.md
+  FullDocumentation: "# ec2\\-ebs\\-encryption\\-by\\-default<a name=\"ec2-ebs-encryption-by-default\"\
+    ></a>\n\nCheck that Amazon Elastic Block Store \\(EBS\\) encryption is enabled\
+    \ by default\\. The rule is NON\\_COMPLIANT if the encryption is not enabled\\\
+    . \n\n**Identifier:** EC2\\_EBS\\_ENCRYPTION\\_BY\\_DEFAULT\n\n**Trigger type:**\
+    \ Periodic\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7d155c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_EBS_ENCRYPTION_BY_DEFAULT
+  Name: ec2-ebs-encryption-by-default
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether your Amazon Elastic Compute Cloud \(Amazon EC2\) instance
+    metadata version is configured with Instance Metadata Service Version 2 \(IMDSv2\)\.
+    The rule is NON\_COMPLIANT if the HttpTokens is set to optional\.
+  File: ec2-imdsv2-check.md
+  FullDocumentation: "# ec2\\-imdsv2\\-check<a name=\"ec2-imdsv2-check\"></a>\n\n\
+    Checks whether your Amazon Elastic Compute Cloud \\(Amazon EC2\\) instance metadata\
+    \ version is configured with Instance Metadata Service Version 2 \\(IMDSv2\\)\\\
+    . The rule is NON\\_COMPLIANT if the HttpTokens is set to optional\\. \n\n**Identifier:**\
+    \ EC2\\_IMDSV2\\_CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\\
+    (Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d157c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_IMDSV2_CHECK
+  Name: ec2-imdsv2-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if detailed monitoring is enabled for EC2 instances\. The rule
+    is NON\_COMPLIANT if detailed monitoring is not enabled\.
+  File: ec2-instance-detailed-monitoring-enabled.md
+  FullDocumentation: "# ec2\\-instance\\-detailed\\-monitoring\\-enabled<a name=\"\
+    ec2-instance-detailed-monitoring-enabled\"></a>\n\nChecks if detailed monitoring\
+    \ is enabled for EC2 instances\\. The rule is NON\\_COMPLIANT if detailed monitoring\
+    \ is not enabled\\.\n\n**Identifier:** EC2\\_INSTANCE\\_DETAILED\\_MONITORING\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d159c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_INSTANCE_DETAILED_MONITORING_ENABLED
+  Name: ec2-instance-detailed-monitoring-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\) Region
+  Description: Checks if the Amazon EC2 instances in your account are managed by AWS
+    Systems Manager\. The rule is NON\_COMPLIANT if the Amazon EC2 instance has lost
+    connection\.
+  File: ec2-instance-managed-by-systems-manager.md
+  FullDocumentation: "# ec2\\-instance\\-managed\\-by\\-systems\\-manager<a name=\"\
+    ec2-instance-managed-by-systems-manager\"></a>\n\nChecks if the Amazon EC2 instances\
+    \ in your account are managed by AWS Systems Manager\\. The rule is NON\\_COMPLIANT\
+    \ if the Amazon EC2 instance has lost connection\\.\n\n**Identifier:** EC2\\_INSTANCE\\\
+    _MANAGED\\_BY\\_SSM\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Jakarta\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d161c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_INSTANCE_MANAGED_BY_SSM
+  Name: ec2-instance-managed-by-systems-manager
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), AWS GovCloud
+    \(US\-West\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\) Region
+  Description: Checks if Amazon Elastic Compute Cloud \(Amazon EC2\) uses multiple
+    ENIs \(Elastic Network Interfaces\) or Elastic Fabric Adapters \(EFAs\)\. This
+    rule is NON\_COMPLIANT an Amazon EC2 instance use multiple network interfaces\.
+  File: ec2-instance-multiple-eni-check.md
+  FullDocumentation: "# ec2\\-instance\\-multiple\\-eni\\-check<a name=\"ec2-instance-multiple-eni-check\"\
+    ></a>\n\nChecks if Amazon Elastic Compute Cloud \\(Amazon EC2\\) uses multiple\
+    \ ENIs \\(Elastic Network Interfaces\\) or Elastic Fabric Adapters \\(EFAs\\)\\\
+    . This rule is NON\\_COMPLIANT an Amazon EC2 instance use multiple network interfaces\\\
+    . \n\n**Identifier:** EC2\\_INSTANCE\\_MULTIPLE\\_ENI\\_CHECK\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except AWS\
+    \ GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNetworkInterfaceIds \\\
+    (Optional\\)Type: CSV  \nComma\\-separated list of network instance IDs\n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7d163c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_INSTANCE_MULTIPLE_ENI_CHECK
+  Name: ec2-instance-multiple-eni-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks whether Amazon Elastic Compute Cloud \(Amazon EC2\) instances
+    have a public IP association\. The rule is NON\_COMPLIANT if the publicIp field
+    is present in the Amazon EC2 instance configuration item\. This rule applies only
+    to IPv4\.
+  File: ec2-instance-no-public-ip.md
+  FullDocumentation: "# ec2\\-instance\\-no\\-public\\-ip<a name=\"ec2-instance-no-public-ip\"\
+    ></a>\n\nChecks whether Amazon Elastic Compute Cloud \\(Amazon EC2\\) instances\
+    \ have a public IP association\\. The rule is NON\\_COMPLIANT if the publicIp\
+    \ field is present in the Amazon EC2 instance configuration item\\. This rule\
+    \ applies only to IPv4\\. \n\n**Identifier:** EC2\\_INSTANCE\\_NO\\_PUBLIC\\_IP\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d165c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_INSTANCE_NO_PUBLIC_IP
+  Name: ec2-instance-no-public-ip
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if an Amazon Elastic Compute Cloud \(Amazon EC2\) instance has
+    an Identity and Access Management \(IAM\) profile attached to it\. This rule is
+    NON\_COMPLIANT if no IAM profile is attached to the Amazon EC2 instance\.
+  File: ec2-instance-profile-attached.md
+  FullDocumentation: "# ec2\\-instance\\-profile\\-attached<a name=\"ec2-instance-profile-attached\"\
+    ></a>\n\nChecks if an Amazon Elastic Compute Cloud \\(Amazon EC2\\) instance has\
+    \ an Identity and Access Management \\(IAM\\) profile attached to it\\. This rule\
+    \ is NON\\_COMPLIANT if no IAM profile is attached to the Amazon EC2 instance\\\
+    . \n\n**Identifier:** EC2\\_INSTANCE\\_PROFILE\\_ATTACHED\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except China\
+    \ \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud\
+    \ \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nIamInstanceProfileArnList \\(Optional\\)Type: CSV  \nComma\\\
+    -separated list of IAM profile Amazon Resource Names \\(ARNs\\) that can be attached\
+    \ to Amazon EC2 instances\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d167c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_INSTANCE_PROFILE_ATTACHED
+  Name: ec2-instance-profile-attached
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if your EC2 instances belong to a virtual private cloud \(VPC\)\.
+    Optionally, you can specify the VPC ID to associate with your instances\.
+  File: ec2-instances-in-vpc.md
+  FullDocumentation: "# ec2\\-instances\\-in\\-vpc<a name=\"ec2-instances-in-vpc\"\
+    ></a>\n\nChecks if your EC2 instances belong to a virtual private cloud \\(VPC\\\
+    )\\. Optionally, you can specify the VPC ID to associate with your instances\\\
+    .\n\n**Identifier:** INSTANCES\\_IN\\_VPC\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nvpcId \\(Optional\\)Type: String  \nVPC ID that contains\
+    \ these EC2 instances\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d319c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: INSTANCES_IN_VPC
+  Name: ec2-instances-in-vpc
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks that none of the specified applications are installed on the
+    instance\. Optionally, specify the version\. Newer versions will not be blacklisted\.
+    Optionally, specify the platform to apply the rule only to instances running that
+    platform\.
+  File: ec2-managedinstance-applications-blacklisted.md
+  FullDocumentation: "# ec2\\-managedinstance\\-applications\\-blacklisted<a name=\"\
+    ec2-managedinstance-applications-blacklisted\"></a>\n\nChecks that none of the\
+    \ specified applications are installed on the instance\\. Optionally, specify\
+    \ the version\\. Newer versions will not be blacklisted\\. Optionally, specify\
+    \ the platform to apply the rule only to instances running that platform\\. \n\
+    \n**Identifier:** EC2\\_MANAGEDINSTANCE\\_APPLICATIONS\\_BLACKLISTED\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\napplicationNamesType:\
+    \ CSV  \nComma\\-separated list of application names\\. Optionally, specify versions\
+    \ appended with ':' \\(for example, 'Chrome:0\\.5\\.3, Firefox'\\)\\.  \nThe application\
+    \ names must be an exact match\\. For example, use **firefox** on Linux or **firefox\\\
+    -compat** on Amazon Linux\\. In addition, AWS Config does not currently support\
+    \ wildcards for the *applicationNames* parameter \\(for example, **firefox\\***\\\
+    )\\.\n\nplatformType \\(Optional\\)Type: String  \nPlatform type \\(for example,\
+    \ 'Linux' or 'Windows'\\)\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d169c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_MANAGEDINSTANCE_APPLICATIONS_BLACKLISTED
+  Name: ec2-managedinstance-applications-blacklisted
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: "Checks if all of the specified applications are installed on the instance\\\
+    . Optionally, specify the minimum acceptable version\\. You can also specify the\
+    \ platform to apply the rule only to instances running that platform\\.\n\n**Note**\
+    \  \nEnsure that SSM agent is running on the EC2 instance and an association to\
+    \ gather application software inventory is created\\. The rule returns NOT\\_APPLICABLE\
+    \ if SSM agent is not installed or an association is yet not created or running\\\
+    ."
+  File: ec2-managedinstance-applications-required.md
+  FullDocumentation: "# ec2\\-managedinstance\\-applications\\-required<a name=\"\
+    ec2-managedinstance-applications-required\"></a>\n\nChecks if all of the specified\
+    \ applications are installed on the instance\\. Optionally, specify the minimum\
+    \ acceptable version\\. You can also specify the platform to apply the rule only\
+    \ to instances running that platform\\.\n\n**Note**  \nEnsure that SSM agent is\
+    \ running on the EC2 instance and an association to gather application software\
+    \ inventory is created\\. The rule returns NOT\\_APPLICABLE if SSM agent is not\
+    \ installed or an association is yet not created or running\\.\n\n**Identifier:**\
+    \ EC2\\_MANAGEDINSTANCE\\_APPLICATIONS\\_REQUIRED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Osaka\\) Region\n\n**Parameters:**\n\napplicationNamesType: CSV  \nComma\\-separated\
+    \ list of application names\\. Optionally, specify versions appended with ':'\
+    \ \\(for example, 'Chrome:0\\.5\\.3, Firefox'\\)\\.  \nThe application names must\
+    \ be an exact match\\. For example, use **firefox** on Linux or **firefox\\-compat**\
+    \ on Amazon Linux\\. In addition, AWS Config does not currently support wildcards\
+    \ for the *applicationNames* parameter \\(for example, **firefox\\***\\)\\.\n\n\
+    platformType \\(Optional\\)Type: String  \nPlatform type \\(for example, 'Linux'\
+    \ or 'Windows'\\)\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d171c17\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_MANAGEDINSTANCE_APPLICATIONS_REQUIRED
+  Name: ec2-managedinstance-applications-required
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if the status of the AWS Systems Manager association compliance
+    is COMPLIANT or NON\_COMPLIANT after the association execution on the instance\.
+    The rule is compliant if the field status is COMPLIANT\. For more information
+    about associations, see [What is an association?](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-state.html#state-manager-association-what-is)\.
+  File: ec2-managedinstance-association-compliance-status-check.md
+  FullDocumentation: "# ec2\\-managedinstance\\-association\\-compliance\\-status\\\
+    -check<a name=\"ec2-managedinstance-association-compliance-status-check\"></a>\n\
+    \nChecks if the status of the AWS Systems Manager association compliance is COMPLIANT\
+    \ or NON\\_COMPLIANT after the association execution on the instance\\. The rule\
+    \ is compliant if the field status is COMPLIANT\\. For more information about\
+    \ associations, see [What is an association?](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-state.html#state-manager-association-what-is)\\\
+    .\n\n**Identifier:** EC2\\_MANAGEDINSTANCE\\_ASSOCIATION\\_COMPLIANCE\\_STATUS\\\
+    _CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7d173c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_MANAGEDINSTANCE_ASSOCIATION_COMPLIANCE_STATUS_CHECK
+  Name: ec2-managedinstance-association-compliance-status-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks whether instances managed by Amazon EC2 Systems Manager are
+    configured to collect blacklisted inventory types\.
+  File: ec2-managedinstance-inventory-blacklisted.md
+  FullDocumentation: "# ec2\\-managedinstance\\-inventory\\-blacklisted<a name=\"\
+    ec2-managedinstance-inventory-blacklisted\"></a>\n\nChecks whether instances managed\
+    \ by Amazon EC2 Systems Manager are configured to collect blacklisted inventory\
+    \ types\\. \n\n**Identifier:** EC2\\_MANAGEDINSTANCE\\_INVENTORY\\_BLACKLISTED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\ninventoryNamesType:\
+    \ CSV  \nComma separated list of Systems Manager inventory types \\(for example,\
+    \ 'AWS:Network, AWS:WindowsUpdate'\\)\\.\n\nplatformType \\(Optional\\)Type: String\
+    \  \nPlatform type \\(for example, 'Linux'\\)\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d175c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_MANAGEDINSTANCE_INVENTORY_BLACKLISTED
+  Name: ec2-managedinstance-inventory-blacklisted
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Middle East \(Bahrain\), Africa \(Cape Town\) Region
+  Description: Checks whether the compliance status of the AWS Systems Manager patch
+    compliance is COMPLIANT or NON\_COMPLIANT after the patch installation on the
+    instance\. The rule is compliant if the field status is COMPLIANT\.
+  File: ec2-managedinstance-patch-compliance-status-check.md
+  FullDocumentation: "# ec2\\-managedinstance\\-patch\\-compliance\\-status\\-check<a\
+    \ name=\"ec2-managedinstance-patch-compliance-status-check\"></a>\n\nChecks whether\
+    \ the compliance status of the AWS Systems Manager patch compliance is COMPLIANT\
+    \ or NON\\_COMPLIANT after the patch installation on the instance\\. The rule\
+    \ is compliant if the field status is COMPLIANT\\. \n\n**Identifier:** EC2\\_MANAGEDINSTANCE\\\
+    _PATCH\\_COMPLIANCE\\_STATUS\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Middle East \\(Bahrain\\), Africa\
+    \ \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d177c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_MANAGEDINSTANCE_PATCH_COMPLIANCE_STATUS_CHECK
+  Name: ec2-managedinstance-patch-compliance-status-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks whether EC2 managed instances have the desired configurations\.
+  File: ec2-managedinstance-platform-check.md
+  FullDocumentation: "# ec2\\-managedinstance\\-platform\\-check<a name=\"ec2-managedinstance-platform-check\"\
+    ></a>\n\nChecks whether EC2 managed instances have the desired configurations\\\
+    . \n\n**Identifier:** EC2\\_MANAGEDINSTANCE\\_PLATFORM\\_CHECK\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nplatformTypeType: String  \n\
+    Platform type \\(for example, 'Linux'\\)\\.\n\nplatformVersion \\(Optional\\)Type:\
+    \ String  \nPlatform version \\(for example, '2016\\.09'\\)\\.\n\nagentVersion\
+    \ \\(Optional\\)Type: String  \nAgent version \\(for example, '2\\.0\\.433\\.0'\\\
+    )\\.\n\nplatformName \\(Optional\\)Type: String  \nThe version of the platform\
+    \ \\(for example, '2016\\.09'\\)\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d179c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_MANAGEDINSTANCE_PLATFORM_CHECK
+  Name: ec2-managedinstance-platform-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if running Amazon Elastic Compute Cloud \(EC2\) instances are
+    launched using amazon key pairs\. The rule is NON\_COMPLIANT if a running EC2
+    instance is launched with a key pair\.
+  File: ec2-no-amazon-key-pair.md
+  FullDocumentation: "# ec2\\-no\\-amazon\\-key\\-pair<a name=\"ec2-no-amazon-key-pair\"\
+    ></a>\n\nChecks if running Amazon Elastic Compute Cloud \\(EC2\\) instances are\
+    \ launched using amazon key pairs\\. The rule is NON\\_COMPLIANT if a running\
+    \ EC2 instance is launched with a key pair\\. \n\n**Identifier:** EC2\\_NO\\_AMAZON\\\
+    _KEY\\_PAIR\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All\
+    \ supported AWS regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d181c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_NO_AMAZON_KEY_PAIR
+  Name: ec2-no-amazon-key-pair
+  TriggerType: Configuration changes
+- AWSRegion: Only available in Europe \(Ireland\), Europe \(Frankfurt\), South America
+    \(Sao Paulo\), US East \(N\. Virginia\), Asia Pacific \(Tokyo\), US West \(Oregon\),
+    US West \(N\. California\), Asia Pacific \(Singapore\), Asia Pacific \(Sydney\)
+    Region
+  Description: Checks if the virtualization type of an EC2 instance is paravirtual\.
+    This rule is NON\_COMPLIANT for an EC2 instance if 'virtualizationType' is set
+    to 'paravirtual'\.
+  File: ec2-paravirtual-instance-check.md
+  FullDocumentation: "# ec2\\-paravirtual\\-instance\\-check<a name=\"ec2-paravirtual-instance-check\"\
+    ></a>\n\nChecks if the virtualization type of an EC2 instance is paravirtual\\\
+    . This rule is NON\\_COMPLIANT for an EC2 instance if 'virtualizationType' is\
+    \ set to 'paravirtual'\\. \n\n**Identifier:** EC2\\_PARAVIRTUAL\\_INSTANCE\\_CHECK\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** Only available in\
+    \ Europe \\(Ireland\\), Europe \\(Frankfurt\\), South America \\(Sao Paulo\\),\
+    \ US East \\(N\\. Virginia\\), Asia Pacific \\(Tokyo\\), US West \\(Oregon\\),\
+    \ US West \\(N\\. California\\), Asia Pacific \\(Singapore\\), Asia Pacific \\\
+    (Sydney\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d183c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_PARAVIRTUAL_INSTANCE_CHECK
+  Name: ec2-paravirtual-instance-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: "Checks if Amazon Elastic Compute Cloud \\(Amazon EC2\\) instances\
+    \ are protected by a backup plan\\. The rule is NON\\_COMPLIANT if the Amazon\
+    \ EC2 instance is not covered by a backup plan\\.\n\n**Note**  \nThis rule is\
+    \ only applicable to running Amazon EC2 instances and not to instances that are\
+    \ powered down\\."
+  File: ec2-resources-protected-by-backup-plan.md
+  FullDocumentation: "# ec2\\-resources\\-protected\\-by\\-backup\\-plan<a name=\"\
+    ec2-resources-protected-by-backup-plan\"></a>\n\nChecks if Amazon Elastic Compute\
+    \ Cloud \\(Amazon EC2\\) instances are protected by a backup plan\\. The rule\
+    \ is NON\\_COMPLIANT if the Amazon EC2 instance is not covered by a backup plan\\\
+    .\n\n**Note**  \nThis rule is only applicable to running Amazon EC2 instances\
+    \ and not to instances that are powered down\\.\n\n**Identifier:** EC2\\_RESOURCES\\\
+    _PROTECTED\\_BY\\_BACKUP\\_PLAN\n\n**Trigger type:** Periodic\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\\
+    ), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nresourceTags \\(Optional\\\
+    )Type: String  \nTags for Amazon EC2 instances for the rule to check, in JSON\
+    \ format\\.\n\nresourceId \\(Optional\\)Type: String  \nID of Amazon EC2 instance\
+    \ for the rule to check\\.\n\ncrossRegionList \\(Optional\\)Type: String  \nComma\\\
+    -separated list of destination regions for the cross\\-region backup copy to be\
+    \ kept\n\ncrossAccountList \\(Optional\\)Type: String  \nComma\\-separated list\
+    \ of destination accounts for cross\\-account backup copy to be kept\n\nmaxRetentionDays\
+    \ \\(Optional\\)Type: int  \nThe maximum retention period in days for the Backup\
+    \ Vault Lock\n\nminRetentionDays \\(Optional\\)Type: int  \nThe minimum retention\
+    \ period in days for the Backup Vault Lock\n\nbackupVaultLockCheck \\(Optional\\\
+    )Type: String  \nAccepted values: 'True' or 'False'\\. Enter 'True' for the rule\
+    \ to check if the resource is backed up in a locked vault\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d185c17\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_RESOURCES_PROTECTED_BY_BACKUP_PLAN
+  Name: ec2-resources-protected-by-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks if non\-default security groups are attached to Elastic network
+    interfaces \(ENIs\)\. The rule is NON\_COMPLIANT if the security group is not
+    associated with an elastic network interface \(ENI\)\.
+  File: ec2-security-group-attached-to-eni-periodic.md
+  FullDocumentation: "# ec2\\-security\\-group\\-attached\\-to\\-eni\\-periodic<a\
+    \ name=\"ec2-security-group-attached-to-eni-periodic\"></a>\n\nChecks if non\\\
+    -default security groups are attached to Elastic network interfaces \\(ENIs\\\
+    )\\. The rule is NON\\_COMPLIANT if the security group is not associated with\
+    \ an elastic network interface \\(ENI\\)\\. \n\n**Identifier:** EC2\\_SECURITY\\\
+    _GROUP\\_ATTACHED\\_TO\\_ENI\\_PERIODIC\n\n**Trigger type:** Periodic\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d189c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_SECURITY_GROUP_ATTACHED_TO_ENI_PERIODIC
+  Name: ec2-security-group-attached-to-eni-periodic
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: "Checks if non\\-default security groups are attached to Elastic network\
+    \ interfaces \\(ENIs\\)\\. The rule is NON\\_COMPLIANT if the security group is\
+    \ not associated with an elastic network interface \\(ENI\\)\\. \n\n**Important**\
+    \  \nThis rule is being deprecated due to [Indirect Relationship Deprecation](https://docs.aws.amazon.com/config/latest/developerguide/faq.html#faq)\
+    \ as configuration items triggering this rule will not longer be created once\
+    \ indirect relationships are deprecated\\. If you use this rule, please remove\
+    \ it from evaluating the configuration of AWS resources and replace it with the\
+    \ new [ec2\\-security\\-group\\-attached\\-to\\-eni\\-periodic](https://docs.aws.amazon.com/config/latest/developerguide/ec2-security-group-attached-to-eni-periodic.html)\
+    \ rule\\. The [ec2\\-security\\-group\\-attached\\-to\\-eni\\-periodic](https://docs.aws.amazon.com/config/latest/developerguide/ec2-security-group-attached-to-eni-periodic.html)\
+    \ rule will not be impacted by this deprecation as it is triggered on a periodic\
+    \ basis rather than on configuration changes\\."
+  File: ec2-security-group-attached-to-eni.md
+  FullDocumentation: "# ec2\\-security\\-group\\-attached\\-to\\-eni<a name=\"ec2-security-group-attached-to-eni\"\
+    ></a>\n\nChecks if non\\-default security groups are attached to Elastic network\
+    \ interfaces \\(ENIs\\)\\. The rule is NON\\_COMPLIANT if the security group is\
+    \ not associated with an elastic network interface \\(ENI\\)\\. \n\n**Important**\
+    \  \nThis rule is being deprecated due to [Indirect Relationship Deprecation](https://docs.aws.amazon.com/config/latest/developerguide/faq.html#faq)\
+    \ as configuration items triggering this rule will not longer be created once\
+    \ indirect relationships are deprecated\\. If you use this rule, please remove\
+    \ it from evaluating the configuration of AWS resources and replace it with the\
+    \ new [ec2\\-security\\-group\\-attached\\-to\\-eni\\-periodic](https://docs.aws.amazon.com/config/latest/developerguide/ec2-security-group-attached-to-eni-periodic.html)\
+    \ rule\\. The [ec2\\-security\\-group\\-attached\\-to\\-eni\\-periodic](https://docs.aws.amazon.com/config/latest/developerguide/ec2-security-group-attached-to-eni-periodic.html)\
+    \ rule will not be impacted by this deprecation as it is triggered on a periodic\
+    \ basis rather than on configuration changes\\.\n\n**Identifier:** EC2\\_SECURITY\\\
+    _GROUP\\_ATTACHED\\_TO\\_ENI\n\n**Trigger type:** Configuration changes\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d187c17\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_SECURITY_GROUP_ATTACHED_TO_ENI
+  Name: ec2-security-group-attached-to-eni
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if there are instances stopped for more than the allowed number
+    of days\. The instance is NON\_COMPLIANT if the state of the ec2 instance has
+    been stopped for longer than the allowed number of days\.
+  File: ec2-stopped-instance.md
+  FullDocumentation: "# ec2\\-stopped\\-instance<a name=\"ec2-stopped-instance\"></a>\n\
+    \nChecks if there are instances stopped for more than the allowed number of days\\\
+    . The instance is NON\\_COMPLIANT if the state of the ec2 instance has been stopped\
+    \ for longer than the allowed number of days\\.\n\n**Identifier:** EC2\\_STOPPED\\\
+    _INSTANCE\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions\
+    \ except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\\
+    ), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nAllowedDays \\(Optional\\\
+    )Type: intDefault: 30  \nThe number of days an ec2 instance can be stopped before\
+    \ it is NON\\_COMPLIANT\\. The default number of days is 30\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d191c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_STOPPED_INSTANCE
+  Name: ec2-stopped-instance
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks if an Amazon Elastic Compute Cloud \(EC2\) instance metadata
+    has a specified token hop limit that is below the desired limit\. The rule is
+    NON\_COMPLIANT for an instance if it has a hop limit value above the intended
+    limit\.
+  File: ec2-token-hop-limit-check.md
+  FullDocumentation: "# ec2\\-token\\-hop\\-limit\\-check<a name=\"ec2-token-hop-limit-check\"\
+    ></a>\n\nChecks if an Amazon Elastic Compute Cloud \\(EC2\\) instance metadata\
+    \ has a specified token hop limit that is below the desired limit\\. The rule\
+    \ is NON\\_COMPLIANT for an instance if it has a hop limit value above the intended\
+    \ limit\\. \n\n**Identifier:** EC2\\_TOKEN\\_HOP\\_LIMIT\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\ntokenHopLimit \\(Optional\\)Type: int  \nThe desired token\
+    \ hop limit\\. Valid values are between 1 and 64, both inclusive\\. Default value\
+    \ is 1 if parameter is not specified\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d193c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: EC2_TOKEN_HOP_LIMIT_CHECK
+  Name: ec2-token-hop-limit-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Hong Kong\), Asia Pacific
+    \(Osaka\), Asia Pacific \(Mumbai\), Middle East \(Bahrain\) Region
+  Description: Checks if Amazon Elastic Compute Cloud \(Amazon EC2\) Transit Gateways
+    have 'AutoAcceptSharedAttachments' enabled\. The rule is NON\_COMPLIANT for a
+    Transit Gateway if 'AutoAcceptSharedAttachments' is set to 'enable'\.
+  File: ec2-transit-gateway-auto-vpc-attach-disabled.md
+  FullDocumentation: "# ec2\\-transit\\-gateway\\-auto\\-vpc\\-attach\\-disabled<a\
+    \ name=\"ec2-transit-gateway-auto-vpc-attach-disabled\"></a>\n\nChecks if Amazon\
+    \ Elastic Compute Cloud \\(Amazon EC2\\) Transit Gateways have 'AutoAcceptSharedAttachments'\
+    \ enabled\\. The rule is NON\\_COMPLIANT for a Transit Gateway if 'AutoAcceptSharedAttachments'\
+    \ is set to 'enable'\\. \n\n**Identifier:** EC2\\_TRANSIT\\_GATEWAY\\_AUTO\\_VPC\\\
+    _ATTACH\\_DISABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Hong Kong\\), Asia Pacific\
+    \ \\(Osaka\\), Asia Pacific \\(Mumbai\\), Middle East \\(Bahrain\\) Region\n\n\
+    **Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d195c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_TRANSIT_GATEWAY_AUTO_VPC_ATTACH_DISABLED
+  Name: ec2-transit-gateway-auto-vpc-attach-disabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if EBS volumes are attached to EC2 instances\. Optionally checks
+    if EBS volumes are marked for deletion when an instance is terminated\.
+  File: ec2-volume-inuse-check.md
+  FullDocumentation: "# ec2\\-volume\\-inuse\\-check<a name=\"ec2-volume-inuse-check\"\
+    ></a>\n\nChecks if EBS volumes are attached to EC2 instances\\. Optionally checks\
+    \ if EBS volumes are marked for deletion when an instance is terminated\\.\n\n\
+    **Identifier:** EC2\\_VOLUME\\_INUSE\\_CHECK\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    deleteOnTermination \\(Optional\\)Type: boolean  \nEBS volumes are marked for\
+    \ deletion when an instance is terminated\\. Possible values: True or False \\\
+    (other input values are marked as non\\-compliant\\)\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d197c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EC2_VOLUME_INUSE_CHECK
+  Name: ec2-volume-inuse-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks if a private Amazon Elastic Container Registry \(ECR\) repository
+    has image scanning enabled\. The rule is NON\_COMPLIANT if image scanning is not
+    enabled for the private ECR repository\.
+  File: ecr-private-image-scanning-enabled.md
+  FullDocumentation: "# ecr\\-private\\-image\\-scanning\\-enabled<a name=\"ecr-private-image-scanning-enabled\"\
+    ></a>\n\nChecks if a private Amazon Elastic Container Registry \\(ECR\\) repository\
+    \ has image scanning enabled\\. The rule is NON\\_COMPLIANT if image scanning\
+    \ is not enabled for the private ECR repository\\. \n\n**Identifier:** ECR\\_PRIVATE\\\
+    _IMAGE\\_SCANNING\\_ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d199c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ECR_PRIVATE_IMAGE_SCANNING_ENABLED
+  Name: ecr-private-image-scanning-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if a private Amazon Elastic Container Registry \(ECR\) repository
+    has at least one lifecycle policy configured\. The rule is NON\_COMPLIANT if no
+    lifecycle policy is configured for the ECR private repository\.
+  File: ecr-private-lifecycle-policy-configured.md
+  FullDocumentation: "# ecr\\-private\\-lifecycle\\-policy\\-configured<a name=\"\
+    ecr-private-lifecycle-policy-configured\"></a>\n\nChecks if a private Amazon Elastic\
+    \ Container Registry \\(ECR\\) repository has at least one lifecycle policy configured\\\
+    . The rule is NON\\_COMPLIANT if no lifecycle policy is configured for the ECR\
+    \ private repository\\. \n\n**Identifier:** ECR\\_PRIVATE\\_LIFECYCLE\\_POLICY\\\
+    _CONFIGURED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All\
+    \ supported AWS regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d201c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ECR_PRIVATE_LIFECYCLE_POLICY_CONFIGURED
+  Name: ecr-private-lifecycle-policy-configured
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks if a private Amazon Elastic Container Registry \(ECR\) repository
+    has tag immutability enabled\. This rule is NON\_COMPLIANT if tag immutability
+    is not enabled for the private ECR repository\.
+  File: ecr-private-tag-immutability-enabled.md
+  FullDocumentation: "# ecr\\-private\\-tag\\-immutability\\-enabled<a name=\"ecr-private-tag-immutability-enabled\"\
+    ></a>\n\nChecks if a private Amazon Elastic Container Registry \\(ECR\\) repository\
+    \ has tag immutability enabled\\. This rule is NON\\_COMPLIANT if tag immutability\
+    \ is not enabled for the private ECR repository\\. \n\n**Identifier:** ECR\\_PRIVATE\\\
+    _TAG\\_IMMUTABILITY\\_ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d203c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ECR_PRIVATE_TAG_IMMUTABILITY_ENABLED
+  Name: ecr-private-tag-immutability-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: "Checks if the privileged parameter in the container definition of\
+    \ ECSTaskDefinitions is set to \u2018true\u2019\\. The rule is NON\\_COMPLIANT\
+    \ if the privileged parameter is \u2018true\u2019\\."
+  File: ecs-containers-nonprivileged.md
+  FullDocumentation: "# ecs\\-containers\\-nonprivileged<a name=\"ecs-containers-nonprivileged\"\
+    ></a>\n\nChecks if the privileged parameter in the container definition of ECSTaskDefinitions\
+    \ is set to \u2018true\u2019\\. The rule is NON\\_COMPLIANT if the privileged\
+    \ parameter is \u2018true\u2019\\. \n\n**Identifier:** ECS\\_CONTAINERS\\_NONPRIVILEGED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\
+    \n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d205c15\"></a>\n\nTo\
+    \ create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ECS_CONTAINERS_NONPRIVILEGED
+  Name: ecs-containers-nonprivileged
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: "Checks if Amazon Elastic Container Service \\(Amazon ECS\\) Containers\
+    \ only have read\\-only access to its root filesystems\\. The rule is NON\\_COMPLIANT\
+    \ if the readonlyRootFilesystem parameter in the container definition of ECSTaskDefinitions\
+    \ is set to \u2018false\u2019\\."
+  File: ecs-containers-readonly-access.md
+  FullDocumentation: "# ecs\\-containers\\-readonly\\-access<a name=\"ecs-containers-readonly-access\"\
+    ></a>\n\nChecks if Amazon Elastic Container Service \\(Amazon ECS\\) Containers\
+    \ only have read\\-only access to its root filesystems\\. The rule is NON\\_COMPLIANT\
+    \ if the readonlyRootFilesystem parameter in the container definition of ECSTaskDefinitions\
+    \ is set to \u2018false\u2019\\. \n\n**Identifier:** ECS\\_CONTAINERS\\_READONLY\\\
+    _ACCESS\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d207c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ECS_CONTAINERS_READONLY_ACCESS
+  Name: ecs-containers-readonly-access
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks if secrets are passed as container environment variables\. The
+    rule is NON\_COMPLIANT if 1 or more environment variable key matches a key listed
+    in the '`secretKeys`' parameter \(excluding environmental variables from other
+    locations such as Amazon S3\)\.
+  File: ecs-no-environment-secrets.md
+  FullDocumentation: "# ecs\\-no\\-environment\\-secrets<a name=\"ecs-no-environment-secrets\"\
+    ></a>\n\nChecks if secrets are passed as container environment variables\\. The\
+    \ rule is NON\\_COMPLIANT if 1 or more environment variable key matches a key\
+    \ listed in the '`secretKeys`' parameter \\(excluding environmental variables\
+    \ from other locations such as Amazon S3\\)\\. \n\n**Identifier:** ECS\\_NO\\\
+    _ENVIRONMENT\\_SECRETS\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\
+    \nsecretKeysType: CSV  \nComma\\-separated list of key names to search for in\
+    \ the environment variables of container definitions within Task Definitions\\\
+    . Extra spaces will be removed\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d209c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: ECS_NO_ENVIRONMENT_SECRETS
+  Name: ecs-no-environment-secrets
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: "Checks if Amazon Elastic Container Service \\(ECS\\) task definitions\
+    \ have a set memory limit for its container definitions\\. The rule is NON\\_COMPLIANT\
+    \ for a task definition if the \u2018memory\u2019 parameter is absent for one\
+    \ container definition\\."
+  File: ecs-task-definition-memory-hard-limit.md
+  FullDocumentation: "# ecs\\-task\\-definition\\-memory\\-hard\\-limit<a name=\"\
+    ecs-task-definition-memory-hard-limit\"></a>\n\nChecks if Amazon Elastic Container\
+    \ Service \\(ECS\\) task definitions have a set memory limit for its container\
+    \ definitions\\. The rule is NON\\_COMPLIANT for a task definition if the \u2018\
+    memory\u2019 parameter is absent for one container definition\\. \n\n**Identifier:**\
+    \ ECS\\_TASK\\_DEFINITION\\_MEMORY\\_HARD\\_LIMIT\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d211c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ECS_TASK_DEFINITION_MEMORY_HARD_LIMIT
+  Name: ecs-task-definition-memory-hard-limit
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: "Checks if ECSTaskDefinitions specify a user for Amazon Elastic Container\
+    \ Service \\(Amazon ECS\\) EC2 launch type containers to run on\\. The rule is\
+    \ NON\\_COMPLIANT if the \u2018user\u2019 parameter is not present or set to \u2018\
+    root\u2019\\."
+  File: ecs-task-definition-nonroot-user.md
+  FullDocumentation: "# ecs\\-task\\-definition\\-nonroot\\-user<a name=\"ecs-task-definition-nonroot-user\"\
+    ></a>\n\nChecks if ECSTaskDefinitions specify a user for Amazon Elastic Container\
+    \ Service \\(Amazon ECS\\) EC2 launch type containers to run on\\. The rule is\
+    \ NON\\_COMPLIANT if the \u2018user\u2019 parameter is not present or set to \u2018\
+    root\u2019\\. \n\n**Identifier:** ECS\\_TASK\\_DEFINITION\\_NONROOT\\_USER\n\n\
+    **Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS regions\
+    \ except Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d213c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ECS_TASK_DEFINITION_NONROOT_USER
+  Name: ecs-task-definition-nonroot-user
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: "Checks if ECSTaskDefinitions are configured to share a host\u2019\
+    s process namespace with its Amazon Elastic Container Service \\(Amazon ECS\\\
+    ) containers\\. The rule is NON\\_COMPLIANT if the pidMode parameter is set to\
+    \ \u2018host\u2019\\."
+  File: ecs-task-definition-pid-mode-check.md
+  FullDocumentation: "# ecs\\-task\\-definition\\-pid\\-mode\\-check<a name=\"ecs-task-definition-pid-mode-check\"\
+    ></a>\n\nChecks if ECSTaskDefinitions are configured to share a host\u2019s process\
+    \ namespace with its Amazon Elastic Container Service \\(Amazon ECS\\) containers\\\
+    . The rule is NON\\_COMPLIANT if the pidMode parameter is set to \u2018host\u2019\
+    \\. \n\n**Identifier:** ECS\\_TASK\\_DEFINITION\\_PID\\_MODE\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d215c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ECS_TASK_DEFINITION_PID_MODE_CHECK
+  Name: ecs-task-definition-pid-mode-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Osaka\) Region
+  Description: Checks if an Amazon Elastic Container Service \(Amazon ECS\) task definition
+    with host networking mode has 'privileged' or 'user' container definitions\. The
+    rule is NON\_COMPLIANT for task definitions with host network mode and container
+    definitions of privileged=false or empty and user=root or empty\.
+  File: ecs-task-definition-user-for-host-mode-check.md
+  FullDocumentation: "# ecs\\-task\\-definition\\-user\\-for\\-host\\-mode\\-check<a\
+    \ name=\"ecs-task-definition-user-for-host-mode-check\"></a>\n\nChecks if an Amazon\
+    \ Elastic Container Service \\(Amazon ECS\\) task definition with host networking\
+    \ mode has 'privileged' or 'user' container definitions\\. The rule is NON\\_COMPLIANT\
+    \ for task definitions with host network mode and container definitions of privileged=false\
+    \ or empty and user=root or empty\\.\n\n**Identifier:** ECS\\_TASK\\_DEFINITION\\\
+    _USER\\_FOR\\_HOST\\_MODE\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except China \\(Beijing\\), China\
+    \ \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nSkipInactiveTaskDefinitions\
+    \ \\(Optional\\)Type: boolean  \nThis rule will evaluate all Amazon ECS Task Definitions\
+    \ if the value is 'false'\\. The rule does not evaluate INACTIVE ECS Task Definitions\
+    \ if the value is 'true'\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d217c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK
+  Name: ecs-task-definition-user-for-host-mode-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if Amazon Elastic File System \(Amazon EFS\) access points are
+    configured to enforce a root directory\. The rule is NON\_COMPLIANT if the value
+    of 'Path' is set to '/' \(default root directory of the file system\)\.
+  File: efs-access-point-enforce-root-directory.md
+  FullDocumentation: "# efs\\-access\\-point\\-enforce\\-root\\-directory<a name=\"\
+    efs-access-point-enforce-root-directory\"></a>\n\nChecks if Amazon Elastic File\
+    \ System \\(Amazon EFS\\) access points are configured to enforce a root directory\\\
+    . The rule is NON\\_COMPLIANT if the value of 'Path' is set to '/' \\(default\
+    \ root directory of the file system\\)\\. \n\n**Identifier:** EFS\\_ACCESS\\_POINT\\\
+    _ENFORCE\\_ROOT\\_DIRECTORY\n\n**Trigger type:** Configuration changes\n\n**AWS\
+    \ Region:** All supported AWS regions\n\n**Parameters:**\n\napprovedDirectories\
+    \ \\(Optional\\)Type: CSV  \nComma\\-separated list of subdirectory paths that\
+    \ are approved for Amazon EFS access point root directory enforcement\\.\n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7d219c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EFS_ACCESS_POINT_ENFORCE_ROOT_DIRECTORY
+  Name: efs-access-point-enforce-root-directory
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if Amazon Elastic File System \(Amazon EFS\) access points are
+    configured to enforce a user identity\. The rule is NON\_COMPLIANT if 'PosixUser'
+    is not defined or if parameters are provided and there is no match in the corresponding
+    parameter\.
+  File: efs-access-point-enforce-user-identity.md
+  FullDocumentation: "# efs\\-access\\-point\\-enforce\\-user\\-identity<a name=\"\
+    efs-access-point-enforce-user-identity\"></a>\n\nChecks if Amazon Elastic File\
+    \ System \\(Amazon EFS\\) access points are configured to enforce a user identity\\\
+    . The rule is NON\\_COMPLIANT if 'PosixUser' is not defined or if parameters are\
+    \ provided and there is no match in the corresponding parameter\\. \n\n**Identifier:**\
+    \ EFS\\_ACCESS\\_POINT\\_ENFORCE\\_USER\\_IDENTITY\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    approvedUids \\(Optional\\)Type: CSV  \nComma\\-separated list of POSIX user ID\
+    \ that are approved for EFS access point user enforcement\\.\n\napprovedGids \\\
+    (Optional\\)Type: CSV  \nComma\\-separated list of POSIX group IDs that are approved\
+    \ for EFS access point user enforcement\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d221c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EFS_ACCESS_POINT_ENFORCE_USER_IDENTITY
+  Name: efs-access-point-enforce-user-identity
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if Amazon Elastic File System \(Amazon EFS\) is configured to
+    encrypt the file data using AWS Key Management Service \(AWS KMS\)\. The rule
+    is NON\_COMPLIANT if the encrypted key is set to false on `DescribeFileSystems`
+    or if the `KmsKeyId` key on `DescribeFileSystems` does not match the `KmsKeyId`
+    parameter\.
+  File: efs-encrypted-check.md
+  FullDocumentation: "# efs\\-encrypted\\-check<a name=\"efs-encrypted-check\"></a>\n\
+    \nChecks if Amazon Elastic File System \\(Amazon EFS\\) is configured to encrypt\
+    \ the file data using AWS Key Management Service \\(AWS KMS\\)\\. The rule is\
+    \ NON\\_COMPLIANT if the encrypted key is set to false on `DescribeFileSystems`\
+    \ or if the `KmsKeyId` key on `DescribeFileSystems` does not match the `KmsKeyId`\
+    \ parameter\\.\n\n**Identifier:** EFS\\_ENCRYPTED\\_CHECK\n\n**Trigger type:**\
+    \ Periodic\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\\
+    ) Region\n\n**Parameters:**\n\nKmsKeyId \\(Optional\\)Type: String  \nAmazon Resource\
+    \ Name \\(ARN\\) of the KMS key that is used to encrypt the EFS file system\\\
+    .\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d223c15\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EFS_ENCRYPTED_CHECK
+  Name: efs-encrypted-check
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), AWS GovCloud
+    \(US\-West\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks whether Amazon Elastic File System \(Amazon EFS\) file systems
+    are added in the backup plans of AWS Backup\. The rule is NON\_COMPLIANT if EFS
+    file systems are not included in the backup plans\.
+  File: efs-in-backup-plan.md
+  FullDocumentation: "# efs\\-in\\-backup\\-plan<a name=\"efs-in-backup-plan\"></a>\n\
+    \nChecks whether Amazon Elastic File System \\(Amazon EFS\\) file systems are\
+    \ added in the backup plans of AWS Backup\\. The rule is NON\\_COMPLIANT if EFS\
+    \ file systems are not included in the backup plans\\. \n\n**Identifier:** EFS\\\
+    _IN\\_BACKUP\\_PLAN\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported\
+    \ AWS regions except AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\\
+    ), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa\
+    \ \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d225c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EFS_IN_BACKUP_PLAN
+  Name: efs-in-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon Elastic File System \(Amazon EFS\) File Systems are
+    protected by a backup plan\. The rule is NON\_COMPLIANT if the EFS File System
+    is not covered by a backup plan\.
+  File: efs-resources-protected-by-backup-plan.md
+  FullDocumentation: "# efs\\-resources\\-protected\\-by\\-backup\\-plan<a name=\"\
+    efs-resources-protected-by-backup-plan\"></a>\n\nChecks if Amazon Elastic File\
+    \ System \\(Amazon EFS\\) File Systems are protected by a backup plan\\. The rule\
+    \ is NON\\_COMPLIANT if the EFS File System is not covered by a backup plan\\\
+    . \n\n**Identifier:** EFS\\_RESOURCES\\_PROTECTED\\_BY\\_BACKUP\\_PLAN\n\n**Trigger\
+    \ type:** Periodic\n\n**AWS Region:** All supported AWS regions except Asia Pacific\
+    \ \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nresourceTags \\(Optional\\)Type: String  \nTags for EFS File Systems for the\
+    \ rule to check, in JSON format\\.\n\nresourceId \\(Optional\\)Type: String  \n\
+    ID of the EFS File System for the rule to check\\.\n\ncrossRegionList \\(Optional\\\
+    )Type: String  \nComma\\-separated list of destination regions for the cross\\\
+    -region backup copy to be kept\n\ncrossAccountList \\(Optional\\)Type: String\
+    \  \nComma\\-separated list of destination accounts for cross\\-account backup\
+    \ copy to be kept\n\nmaxRetentionDays \\(Optional\\)Type: int  \nThe maximum retention\
+    \ period in days for the Backup Vault Lock\n\nminRetentionDays \\(Optional\\)Type:\
+    \ int  \nThe minimum retention period in days for the Backup Vault Lock\n\nbackupVaultLockCheck\
+    \ \\(Optional\\)Type: String  \nAccepted values: 'True' or 'False'\\. Enter 'True'\
+    \ for the rule to check if the resource is backed up in a locked vault\n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d227c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EFS_RESOURCES_PROTECTED_BY_BACKUP_PLAN
+  Name: efs-resources-protected-by-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: "Checks if all Elastic IP addresses that are allocated to an AWS account\
+    \ are attached to EC2 instances or in\\-use elastic network interfaces \\(ENIs\\\
+    )\\.\n\n**Note**  \nResults might take up to 6 hours to become available after\
+    \ an evaluation occurs\\."
+  File: eip-attached.md
+  FullDocumentation: "# eip\\-attached<a name=\"eip-attached\"></a>\n\nChecks if all\
+    \ Elastic IP addresses that are allocated to an AWS account are attached to EC2\
+    \ instances or in\\-use elastic network interfaces \\(ENIs\\)\\.\n\n**Note** \
+    \ \nResults might take up to 6 hours to become available after an evaluation occurs\\\
+    .\n\n**Identifier:** EIP\\_ATTACHED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7d229c17\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EIP_ATTACHED
+  Name: eip-attached
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks if an Amazon Elastic Kubernetes Service \(EKS\) cluster is running
+    the oldest supported version\. The rule is NON\_COMPLIANT if an EKS cluster is
+    running oldest supported version \(equal to the parameter '`oldestVersionSupported`'\)\.
+  File: eks-cluster-oldest-supported-version.md
+  FullDocumentation: "# eks\\-cluster\\-oldest\\-supported\\-version<a name=\"eks-cluster-oldest-supported-version\"\
+    ></a>\n\nChecks if an Amazon Elastic Kubernetes Service \\(EKS\\) cluster is running\
+    \ the oldest supported version\\. The rule is NON\\_COMPLIANT if an EKS cluster\
+    \ is running oldest supported version \\(equal to the parameter '`oldestVersionSupported`'\\\
+    )\\. \n\n**Identifier:** EKS\\_CLUSTER\\_OLDEST\\_SUPPORTED\\_VERSION\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\noldestVersionSupportedType:\
+    \ String  \nValue of the oldest version of Kubernetes supported on AWS\\.\n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7d231c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EKS_CLUSTER_OLDEST_SUPPORTED_VERSION
+  Name: eks-cluster-oldest-supported-version
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks if an Amazon Elastic Kubernetes Service \(EKS\) cluster is running
+    a supported Kubernetes version\. This rule is NON\_COMPLIANT if an EKS cluster
+    is running an unsupported version \(less than the parameter '`oldestVersionSupported`'\)\.
+  File: eks-cluster-supported-version.md
+  FullDocumentation: "# eks\\-cluster\\-supported\\-version<a name=\"eks-cluster-supported-version\"\
+    ></a>\n\nChecks if an Amazon Elastic Kubernetes Service \\(EKS\\) cluster is running\
+    \ a supported Kubernetes version\\. This rule is NON\\_COMPLIANT if an EKS cluster\
+    \ is running an unsupported version \\(less than the parameter '`oldestVersionSupported`'\\\
+    )\\. \n\n**Identifier:** EKS\\_CLUSTER\\_SUPPORTED\\_VERSION\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\noldestVersionSupportedType:\
+    \ String  \nValue of the oldest version of Kubernetes supported on AWS\\.\n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7d233c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EKS_CLUSTER_SUPPORTED_VERSION
+  Name: eks-cluster-supported-version
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), AWS GovCloud
+    \(US\-West\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\),
+    US West \(N\. California\), Africa \(Cape Town\) Region
+  Description: Checks whether Amazon Elastic Kubernetes Service \(Amazon EKS\) endpoint
+    is not publicly accessible\. The rule is NON\_COMPLIANT if the endpoint is publicly
+    accessible\.
+  File: eks-endpoint-no-public-access.md
+  FullDocumentation: "# eks\\-endpoint\\-no\\-public\\-access<a name=\"eks-endpoint-no-public-access\"\
+    ></a>\n\nChecks whether Amazon Elastic Kubernetes Service \\(Amazon EKS\\) endpoint\
+    \ is not publicly accessible\\. The rule is NON\\_COMPLIANT if the endpoint is\
+    \ publicly accessible\\. \n\n**Identifier:** EKS\\_ENDPOINT\\_NO\\_PUBLIC\\_ACCESS\n\
+    \n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions except\
+    \ AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\\
+    (Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), US West \\(N\\. California\\\
+    ), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d235c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EKS_ENDPOINT_NO_PUBLIC_ACCESS
+  Name: eks-endpoint-no-public-access
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), US West \(N\. California\), Africa \(Cape Town\)
+    Region
+  Description: 'Checks if Amazon Elastic Kubernetes Service clusters are configured
+    to have Kubernetes secrets encrypted using AWS Key Management Service \(KMS\)
+    keys\.
+
+    + This rule is COMPLIANT if an EKS cluster has an encryptionConfig with secrets
+    as one of the resources\.
+
+    + This rule is also COMPLIANT if the key used to encrypt EKS secrets matches with
+    the parameter\.
+
+    + This rule is NON\_COMPLIANT if an EKS cluster does not have an encryptionConfig
+    or if the encryptionConfig resources do not include secrets\.
+
+    + This rule is also NON\_COMPLIANT if the key used to encrypt EKS secrets does
+    not match with the parameter\.'
+  File: eks-secrets-encrypted.md
+  FullDocumentation: "# eks\\-secrets\\-encrypted<a name=\"eks-secrets-encrypted\"\
+    ></a>\n\nChecks if Amazon Elastic Kubernetes Service clusters are configured to\
+    \ have Kubernetes secrets encrypted using AWS Key Management Service \\(KMS\\\
+    ) keys\\.\n+ This rule is COMPLIANT if an EKS cluster has an encryptionConfig\
+    \ with secrets as one of the resources\\.\n+ This rule is also COMPLIANT if the\
+    \ key used to encrypt EKS secrets matches with the parameter\\.\n+ This rule is\
+    \ NON\\_COMPLIANT if an EKS cluster does not have an encryptionConfig or if the\
+    \ encryptionConfig resources do not include secrets\\.\n+ This rule is also NON\\\
+    _COMPLIANT if the key used to encrypt EKS secrets does not match with the parameter\\\
+    .\n\n**Identifier:** EKS\\_SECRETS\\_ENCRYPTED\n\n**Trigger type:** Periodic\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), US West \\(N\\. California\\),\
+    \ Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nkmsKeyArns \\(Optional\\\
+    )Type: CSV  \nComma separated list of Amazon Resource Name \\(ARN\\) of the KMS\
+    \ key that should be used for encrypted secrets in an EKS cluster\\.\n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d237c17\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EKS_SECRETS_ENCRYPTED
+  Name: eks-secrets-encrypted
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if managed platform updates in an AWS Elastic Beanstalk environment
+    is enabled\. The rule is COMPLIANT if the value for `ManagedActionsEnabled` is
+    set to true\. The rule is NON\_COMPLIANT if the value for `ManagedActionsEnabled`
+    is set to false, or if a parameter is provided and its value does not match the
+    existing configurations\.
+  File: elastic-beanstalk-managed-updates-enabled.md
+  FullDocumentation: "# elastic\\-beanstalk\\-managed\\-updates\\-enabled<a name=\"\
+    elastic-beanstalk-managed-updates-enabled\"></a>\n\nChecks if managed platform\
+    \ updates in an AWS Elastic Beanstalk environment is enabled\\. The rule is COMPLIANT\
+    \ if the value for `ManagedActionsEnabled` is set to true\\. The rule is NON\\\
+    _COMPLIANT if the value for `ManagedActionsEnabled` is set to false, or if a parameter\
+    \ is provided and its value does not match the existing configurations\\. \n\n\
+    **Identifier:** ELASTIC\\_BEANSTALK\\_MANAGED\\_UPDATES\\_ENABLED\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS\
+    \ GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\\
+    ) Region\n\n**Parameters:**\n\nUpdateLevel \\(Optional\\)Type: String  \nIndicates\
+    \ whether update levels are set to 'minor' version updates or a 'patch' version\
+    \ updates\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d249c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELASTIC_BEANSTALK_MANAGED_UPDATES_ENABLED
+  Name: elastic-beanstalk-managed-updates-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: 'Check if the Amazon ElastiCache Redis clusters have automatic backup
+    turned on\. The rule is NON\_COMPLIANT if the SnapshotRetentionLimit for Redis
+    cluster is less than the SnapshotRetentionPeriod parameter\. For example: If the
+    parameter is 15 then the rule is non\-compliant if the snapshotRetentionPeriod
+    is between 0\-15\.'
+  File: elasticache-redis-cluster-automatic-backup-check.md
+  FullDocumentation: "# elasticache\\-redis\\-cluster\\-automatic\\-backup\\-check<a\
+    \ name=\"elasticache-redis-cluster-automatic-backup-check\"></a>\n\nCheck if the\
+    \ Amazon ElastiCache Redis clusters have automatic backup turned on\\. The rule\
+    \ is NON\\_COMPLIANT if the SnapshotRetentionLimit for Redis cluster is less than\
+    \ the SnapshotRetentionPeriod parameter\\. For example: If the parameter is 15\
+    \ then the rule is non\\-compliant if the snapshotRetentionPeriod is between 0\\\
+    -15\\. \n\n**Identifier:** ELASTICACHE\\_REDIS\\_CLUSTER\\_AUTOMATIC\\_BACKUP\\\
+    _CHECK\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions\
+    \ except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\
+    \nsnapshotRetentionPeriod \\(Optional\\)Type: intDefault: 15  \nMinimum snapshot\
+    \ retention period in days for Redis cluster\\. Default is 15 days\\.\n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d239c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELASTICACHE_REDIS_CLUSTER_AUTOMATIC_BACKUP_CHECK
+  Name: elasticache-redis-cluster-automatic-backup-check
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Ningxia\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if Amazon OpenSearch Service \(OpenSearch Service\) domains
+    have encryption at rest configuration enabled\. The rule is NON\_COMPLIANT if
+    the `EncryptionAtRestOptions` field is not enabled\.
+  File: elasticsearch-encrypted-at-rest.md
+  FullDocumentation: "# elasticsearch\\-encrypted\\-at\\-rest<a name=\"elasticsearch-encrypted-at-rest\"\
+    ></a>\n\nChecks if Amazon OpenSearch Service \\(OpenSearch Service\\) domains\
+    \ have encryption at rest configuration enabled\\. The rule is NON\\_COMPLIANT\
+    \ if the `EncryptionAtRestOptions` field is not enabled\\.\n\n**Identifier:**\
+    \ ELASTICSEARCH\\_ENCRYPTED\\_AT\\_REST\n\n**Trigger type:** Periodic\n\n**AWS\
+    \ Region:** All supported AWS regions except China \\(Ningxia\\), Asia Pacific\
+    \ \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\
+    \n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d241c15\"></a>\n\nTo\
+    \ create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELASTICSEARCH_ENCRYPTED_AT_REST
+  Name: elasticsearch-encrypted-at-rest
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks if Amazon OpenSearch Service \(OpenSearch Service\) domains
+    are in Amazon Virtual Private Cloud \(Amazon VPC\)\. The rule is NON\_COMPLIANT
+    if the OpenSearch Service domain endpoint is public\.
+  File: elasticsearch-in-vpc-only.md
+  FullDocumentation: "# elasticsearch\\-in\\-vpc\\-only<a name=\"elasticsearch-in-vpc-only\"\
+    ></a>\n\n Checks if Amazon OpenSearch Service \\(OpenSearch Service\\) domains\
+    \ are in Amazon Virtual Private Cloud \\(Amazon VPC\\)\\. The rule is NON\\_COMPLIANT\
+    \ if the OpenSearch Service domain endpoint is public\\.\n\n**Identifier:** ELASTICSEARCH\\\
+    _IN\\_VPC\\_ONLY\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d243c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELASTICSEARCH_IN_VPC_ONLY
+  Name: elasticsearch-in-vpc-only
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\) Region
+  Description: Checks if Amazon OpenSearch Service \(OpenSearch Service\) domains
+    are configured to send logs to Amazon CloudWatch Logs\. The rule is COMPLIANT
+    if a log is enabled for an OpenSearch Service domain\. This rule is NON\_COMPLIANT
+    if logging is not configured\.
+  File: elasticsearch-logs-to-cloudwatch.md
+  FullDocumentation: "# elasticsearch\\-logs\\-to\\-cloudwatch<a name=\"elasticsearch-logs-to-cloudwatch\"\
+    ></a>\n\nChecks if Amazon OpenSearch Service \\(OpenSearch Service\\) domains\
+    \ are configured to send logs to Amazon CloudWatch Logs\\. The rule is COMPLIANT\
+    \ if a log is enabled for an OpenSearch Service domain\\. This rule is NON\\_COMPLIANT\
+    \ if logging is not configured\\. \n\n**Identifier:** ELASTICSEARCH\\_LOGS\\_TO\\\
+    _CLOUDWATCH\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All\
+    \ supported AWS regions except China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud\
+    \ \\(US\\-East\\), AWS GovCloud \\(US\\-West\\) Region\n\n**Parameters:**\n\n\
+    logTypes \\(Optional\\)Type: CSV  \nComma\\-separated list of logs that are enabled\\\
+    . Valid values are 'search', 'index', 'error'\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d245c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELASTICSEARCH_LOGS_TO_CLOUDWATCH
+  Name: elasticsearch-logs-to-cloudwatch
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape
+    Town\) Region
+  Description: Check that Amazon OpenSearch Service nodes are encrypted end to end\.
+    The rule is NON\_COMPLIANT if the node\-to\-node encryption is disabled on the
+    domain\.
+  File: elasticsearch-node-to-node-encryption-check.md
+  FullDocumentation: "# elasticsearch\\-node\\-to\\-node\\-encryption\\-check<a name=\"\
+    elasticsearch-node-to-node-encryption-check\"></a>\n\nCheck that Amazon OpenSearch\
+    \ Service nodes are encrypted end to end\\. The rule is NON\\_COMPLIANT if the\
+    \ node\\-to\\-node encryption is disabled on the domain\\. \n\n**Identifier:**\
+    \ ELASTICSEARCH\\_NODE\\_TO\\_NODE\\_ENCRYPTION\\_CHECK\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except China \\(Beijing\\\
+    ), China \\(Ningxia\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\),\
+    \ Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone\
+    \  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d247c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELASTICSEARCH_NODE_TO_NODE_ENCRYPTION_CHECK
+  Name: elasticsearch-node-to-node-encryption-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe
+    \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if the Classic Load Balancers use SSL certificates provided
+    by AWS Certificate Manager\. To use this rule, use an SSL or HTTPS listener with
+    your Classic Load Balancer\. This rule is only applicable to Classic Load Balancers\.
+    This rule does not check Application Load Balancers and Network Load Balancers\.
+  File: elb-acm-certificate-required.md
+  FullDocumentation: "# elb\\-acm\\-certificate\\-required<a name=\"elb-acm-certificate-required\"\
+    ></a>\n\nChecks if the Classic Load Balancers use SSL certificates provided by\
+    \ AWS Certificate Manager\\. To use this rule, use an SSL or HTTPS listener with\
+    \ your Classic Load Balancer\\. This rule is only applicable to Classic Load Balancers\\\
+    . This rule does not check Application Load Balancers and Network Load Balancers\\\
+    .\n\n**Identifier:** ELB\\_ACM\\_CERTIFICATE\\_REQUIRED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except China \\(Beijing\\\
+    ), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d255c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELB_ACM_CERTIFICATE_REQUIRED
+  Name: elb-acm-certificate-required
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks if cross\-zone load balancing is enabled for the Classic Load
+    Balancers \(CLBs\)\. This rule is NON\_COMPLIANT if cross\-zone load balancing
+    is not enabled for a CLB\.
+  File: elb-cross-zone-load-balancing-enabled.md
+  FullDocumentation: "# elb\\-cross\\-zone\\-load\\-balancing\\-enabled<a name=\"\
+    elb-cross-zone-load-balancing-enabled\"></a>\n\nChecks if cross\\-zone load balancing\
+    \ is enabled for the Classic Load Balancers \\(CLBs\\)\\. This rule is NON\\_COMPLIANT\
+    \ if cross\\-zone load balancing is not enabled for a CLB\\. \n\n**Identifier:**\
+    \ ELB\\_CROSS\\_ZONE\\_LOAD\\_BALANCING\\_ENABLED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7d257c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELB_CROSS_ZONE_LOAD_BALANCING_ENABLED
+  Name: elb-cross-zone-load-balancing-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), Asia Pacific
+    \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether your Classic Load Balancer SSL listeners are using a
+    custom policy\. The rule is only applicable if there are SSL listeners for the
+    Classic Load Balancer\.
+  File: elb-custom-security-policy-ssl-check.md
+  FullDocumentation: "# elb\\-custom\\-security\\-policy\\-ssl\\-check<a name=\"elb-custom-security-policy-ssl-check\"\
+    ></a>\n\nChecks whether your Classic Load Balancer SSL listeners are using a custom\
+    \ policy\\. The rule is only applicable if there are SSL listeners for the Classic\
+    \ Load Balancer\\. \n\n**Identifier:** ELB\\_CUSTOM\\_SECURITY\\_POLICY\\_SSL\\\
+    _CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except AWS GovCloud \\(US\\-East\\), Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nsslProtocolsAndCiphersType: String  \nComma\\-separated list\
+    \ of ciphers and protocols\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d259c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELB_CUSTOM_SECURITY_POLICY_SSL_CHECK
+  Name: elb-custom-security-policy-ssl-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks if Elastic Load Balancing has deletion protection enabled\.
+    The rule is NON\_COMPLIANT if `deletion_protection.enabled` is false\.
+  File: elb-deletion-protection-enabled.md
+  FullDocumentation: "# elb\\-deletion\\-protection\\-enabled<a name=\"elb-deletion-protection-enabled\"\
+    ></a>\n\nChecks if Elastic Load Balancing has deletion protection enabled\\. The\
+    \ rule is NON\\_COMPLIANT if `deletion_protection.enabled` is false\\.\n\n**Identifier:**\
+    \ ELB\\_DELETION\\_PROTECTION\\_ENABLED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d261c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELB_DELETION_PROTECTION_ENABLED
+  Name: elb-deletion-protection-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if the Application Load Balancer and the Classic Load Balancer
+    have logging enabled\. The rule is NON\_COMPLIANT if the `access_logs.s3.enabled`
+    is false or `access_logs.S3.bucket` is not equal to the s3BucketName that you
+    provided\.
+  File: elb-logging-enabled.md
+  FullDocumentation: "# elb\\-logging\\-enabled<a name=\"elb-logging-enabled\"></a>\n\
+    \nChecks if the Application Load Balancer and the Classic Load Balancer have logging\
+    \ enabled\\. The rule is NON\\_COMPLIANT if the `access_logs.s3.enabled` is false\
+    \ or `access_logs.S3.bucket` is not equal to the s3BucketName that you provided\\\
+    .\n\n**Identifier:** ELB\\_LOGGING\\_ENABLED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    s3BucketNames \\(Optional\\)Type: CSV  \nComma\\-separated list of Amazon S3 bucket\
+    \ names for Amazon ELB to deliver the log files\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d263c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELB_LOGGING_ENABLED
+  Name: elb-logging-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), Asia Pacific
+    \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether your Classic Load Balancer SSL listeners are using a
+    predefined policy\. The rule is only applicable if there are SSL listeners for
+    the Classic Load Balancer\.
+  File: elb-predefined-security-policy-ssl-check.md
+  FullDocumentation: "# elb\\-predefined\\-security\\-policy\\-ssl\\-check<a name=\"\
+    elb-predefined-security-policy-ssl-check\"></a>\n\nChecks whether your Classic\
+    \ Load Balancer SSL listeners are using a predefined policy\\. The rule is only\
+    \ applicable if there are SSL listeners for the Classic Load Balancer\\. \n\n\
+    **Identifier:** ELB\\_PREDEFINED\\_SECURITY\\_POLICY\\_SSL\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ AWS GovCloud \\(US\\-East\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\\
+    ), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\npredefinedPolicyNameType:\
+    \ String  \nName of the predefined policy\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d265c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK
+  Name: elb-predefined-security-policy-ssl-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: 'Checks if your Classic Load Balancer is configured with SSL or HTTPS
+    listeners\.
+
+    + If the Classic Load Balancer does not have a listener configured, then the rule
+    returns NOT\_APPLICABLE\.
+
+    + The rule is COMPLIANT if the Classic Load Balancer listeners are configured
+    with SSL or HTTPS\.
+
+    + The rule is NON\_COMPLIANT if a listener is not configured with SSL or HTTPS\.'
+  File: elb-tls-https-listeners-only.md
+  FullDocumentation: "# elb\\-tls\\-https\\-listeners\\-only<a name=\"elb-tls-https-listeners-only\"\
+    ></a>\n\nChecks if your Classic Load Balancer is configured with SSL or HTTPS\
+    \ listeners\\.\n+ If the Classic Load Balancer does not have a listener configured,\
+    \ then the rule returns NOT\\_APPLICABLE\\.\n+ The rule is COMPLIANT if the Classic\
+    \ Load Balancer listeners are configured with SSL or HTTPS\\.\n+ The rule is NON\\\
+    _COMPLIANT if a listener is not configured with SSL or HTTPS\\.\n\n**Identifier:**\
+    \ ELB\\_TLS\\_HTTPS\\_LISTENERS\\_ONLY\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d267c17\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELB_TLS_HTTPS_LISTENERS_ONLY
+  Name: elb-tls-https-listeners-only
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), AWS GovCloud
+    \(US\-West\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\) Region
+  Description: Checks if Application Load Balancers and Network Load Balancers have
+    listeners that are configured to use certificates from AWS Certificate Manager
+    \(ACM\)\. This rule is NON\_COMPLIANT if at least 1 load balancer has at least
+    1 listener that is configured without a certificate from ACM or is configured
+    with a certificate different from an ACM certificate\.
+  File: elbv2-acm-certificate-required.md
+  FullDocumentation: "# elbv2\\-acm\\-certificate\\-required<a name=\"elbv2-acm-certificate-required\"\
+    ></a>\n\nChecks if Application Load Balancers and Network Load Balancers have\
+    \ listeners that are configured to use certificates from AWS Certificate Manager\
+    \ \\(ACM\\)\\. This rule is NON\\_COMPLIANT if at least 1 load balancer has at\
+    \ least 1 listener that is configured without a certificate from ACM or is configured\
+    \ with a certificate different from an ACM certificate\\.\n\n**Identifier:** ELBV2\\\
+    _ACM\\_CERTIFICATE\\_REQUIRED\n\n**Trigger type:** Periodic\n\n**AWS Region:**\
+    \ All supported AWS regions except AWS GovCloud \\(US\\-East\\), AWS GovCloud\
+    \ \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nAcmCertificatesAllowed \\(Optional\\)Type: CSV  \nComma\\\
+    -separated list of certificate Amazon Resource Names \\(ARNs\\)\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d251c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELBV2_ACM_CERTIFICATE_REQUIRED
+  Name: elbv2-acm-certificate-required
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks if an Elastic Load Balancer V2 \(Application, Network, or Gateway
+    Load Balancer\) has registered instances from multiple Availability Zones \(AZ's\)\.
+    The rule is NON\_COMPLIANT if an Elastic Load Balancer V2 has instances registered
+    in less than 2 AZ's\.
+  File: elbv2-multiple-az.md
+  FullDocumentation: "# elbv2\\-multiple\\-az<a name=\"elbv2-multiple-az\"></a>\n\n\
+    Checks if an Elastic Load Balancer V2 \\(Application, Network, or Gateway Load\
+    \ Balancer\\) has registered instances from multiple Availability Zones \\(AZ's\\\
+    )\\. The rule is NON\\_COMPLIANT if an Elastic Load Balancer V2 has instances\
+    \ registered in less than 2 AZ's\\. \n\n**Identifier:** ELBV2\\_MULTIPLE\\_AZ\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions\n\n**Parameters:**\n\nminAvailabilityZones \\(Optional\\)Type: int \
+    \ \nMinimum number of expected AZ\u2019s \\(between 2 and 10 inclusive\\)\\.\n\
+    \n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d253c15\"></a>\n\nTo\
+    \ create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ELBV2_MULTIPLE_AZ
+  Name: elbv2-multiple-az
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks if Amazon EMR clusters have Kerberos enabled\. The rule is NON\_COMPLIANT
+    if a security configuration is not attached to the cluster or the security configuration
+    does not satisfy the specified rule parameters\.
+  File: emr-kerberos-enabled.md
+  FullDocumentation: "# emr\\-kerberos\\-enabled<a name=\"emr-kerberos-enabled\"></a>\n\
+    \nChecks if Amazon EMR clusters have Kerberos enabled\\. The rule is NON\\_COMPLIANT\
+    \ if a security configuration is not attached to the cluster or the security configuration\
+    \ does not satisfy the specified rule parameters\\.\n\n**Identifier:** EMR\\_KERBEROS\\\
+    _ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions\
+    \ except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\
+    \nTicketLifetimeInHours \\(Optional\\)Type: int  \nPeriod for which Kerberos ticket\
+    \ issued by cluster's KDC is valid\\.\n\nRealm \\(Optional\\)Type: String  \n\
+    Kereberos realm name of the other realm in the trust relationship\\.\n\nDomain\
+    \ \\(Optional\\)Type: String  \nDomain name of the other realm in the trust relationship\\\
+    .\n\nAdminServer \\(Optional\\)Type: String  \nFully qualified domain of the admin\
+    \ server in the other realm of the trust relationship\\.\n\nKdcServer \\(Optional\\\
+    )Type: String  \nFully qualified domain of the KDC server in the other realm of\
+    \ the trust relationship\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d269c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EMR_KERBEROS_ENABLED
+  Name: emr-kerberos-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: "Checks if Amazon Elastic MapReduce \\(EMR\\) clusters' master nodes\
+    \ have public IPs\\. The rule is NON\\_COMPLIANT if the master node has a public\
+    \ IP\\.\n\n**Note**  \nThis rule checks clusters that are in RUNNING or WAITING\
+    \ state\\."
+  File: emr-master-no-public-ip.md
+  FullDocumentation: "# emr\\-master\\-no\\-public\\-ip<a name=\"emr-master-no-public-ip\"\
+    ></a>\n\nChecks if Amazon Elastic MapReduce \\(EMR\\) clusters' master nodes have\
+    \ public IPs\\. The rule is NON\\_COMPLIANT if the master node has a public IP\\\
+    .\n\n**Note**  \nThis rule checks clusters that are in RUNNING or WAITING state\\\
+    .\n\n**Identifier:** EMR\\_MASTER\\_NO\\_PUBLIC\\_IP\n\n**Trigger type:** Periodic\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d271c17\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: EMR_MASTER_NO_PUBLIC_IP
+  Name: emr-master-no-public-ip
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if the EBS volumes that are in an attached state are encrypted\.
+    If you specify the ID of a KMS key for encryption using the kmsId parameter, the
+    rule checks if the EBS volumes in an attached state are encrypted with that KMS
+    key\.
+  File: encrypted-volumes.md
+  FullDocumentation: "# encrypted\\-volumes<a name=\"encrypted-volumes\"></a>\n\n\
+    Checks if the EBS volumes that are in an attached state are encrypted\\. If you\
+    \ specify the ID of a KMS key for encryption using the kmsId parameter, the rule\
+    \ checks if the EBS volumes in an attached state are encrypted with that KMS key\\\
+    .\n\n**Identifier:** ENCRYPTED\\_VOLUMES\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nkmsId \\(Optional\\)Type: String  \nID or ARN of the KMS\
+    \ key that is used to encrypt the volume\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d273c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ENCRYPTED_VOLUMES
+  Name: encrypted-volumes
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    Asia Pacific \(Jakarta\) Region
+  Description: Checks whether an Application Load Balancer, Amazon CloudFront distributions,
+    Elastic Load Balancer or Elastic IP has AWS Shield protection\. It also checks
+    if they have web ACL associated for Application Load Balancer and Amazon CloudFront
+    distributions\.
+  File: fms-shield-resource-policy-check.md
+  FullDocumentation: "# fms\\-shield\\-resource\\-policy\\-check<a name=\"fms-shield-resource-policy-check\"\
+    ></a>\n\nChecks whether an Application Load Balancer, Amazon CloudFront distributions,\
+    \ Elastic Load Balancer or Elastic IP has AWS Shield protection\\. It also checks\
+    \ if they have web ACL associated for Application Load Balancer and Amazon CloudFront\
+    \ distributions\\. \n\n**Identifier:** FMS\\_SHIELD\\_RESOURCE\\_POLICY\\_CHECK\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except China \\(Beijing\\), China \\(Ningxia\\), Asia Pacific \\(Jakarta\\\
+    ) Region\n\n**Parameters:**\n\nwebACLIdType: String  \nThe WebACLId of the web\
+    \ ACL\\.\n\nresourceTypesType: String  \nThe resource scope which this config\
+    \ rule will be applied to\\.\n\nresourceTags \\(Optional\\)Type: String  \nThe\
+    \ resource tags that the rule should be associated with \\(for example, \\{ \"\
+    tagKey1\" : \\[\"tagValue1\"\\], \"tagKey2\" : \\[\"tagValue2\", \"tagValue3\"\
+    \\] \\}\\)\\.\n\nexcludeResourceTags \\(Optional\\)Type: boolean  \nIf true, exclude\
+    \ the resources that match the resourceTags\\. If false, include all the resources\
+    \ that match the resourceTags\\.\n\nfmsManagedToken \\(Optional\\)Type: String\
+    \  \nA token generated by AWS Firewall Manager when creating the rule in your\
+    \ account\\. AWS Config ignores this parameter when you create this rule\\.\n\n\
+    fmsRemediationEnabled \\(Optional\\)Type: boolean  \nIf true, AWS Firewall Manager\
+    \ will update NON\\_COMPLIANT resources according to FMS policy\\. AWS Config\
+    \ ignores this parameter when you create this rule\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d275c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: FMS_SHIELD_RESOURCE_POLICY_CHECK
+  Name: fms-shield-resource-policy-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\) Region
+  Description: Checks if the web ACL is associated with an Application Load Balancer,
+    API Gateway stage, or Amazon CloudFront distributions\. When AWS Firewall Manager
+    creates this rule, the FMS policy owner specifies the `WebACLId` in the FMS policy
+    and can optionally enable remediation\.
+  File: fms-webacl-resource-policy-check.md
+  FullDocumentation: "# fms\\-webacl\\-resource\\-policy\\-check<a name=\"fms-webacl-resource-policy-check\"\
+    ></a>\n\nChecks if the web ACL is associated with an Application Load Balancer,\
+    \ API Gateway stage, or Amazon CloudFront distributions\\. When AWS Firewall Manager\
+    \ creates this rule, the FMS policy owner specifies the `WebACLId` in the FMS\
+    \ policy and can optionally enable remediation\\.\n\n**Identifier:** FMS\\_WEBACL\\\
+    _RESOURCE\\_POLICY\\_CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\) Region\n\
+    \n**Parameters:**\n\nwebACLIdType: String  \nThe WebACLId of the web ACL\\.\n\n\
+    resourceTags \\(Optional\\)Type: String  \nThe resource tags \\(ApplicationLoadBalancer,\
+    \ ApiGatewayStage and CloudFront distributions\\) that the rule should be associated\
+    \ with\\. \\(for example, \\{ \"tagKey1\" : \\[\"tagValue1\"\\], \"tagKey2\" :\
+    \ \\[\"tagValue2\", \"tagValue3\"\\] \\}\\)\n\nexcludeResourceTags \\(Optional\\\
+    )Type: boolean  \nIf true, exclude resources that match resourceTags\\.\n\nfmsManagedToken\
+    \ \\(Optional\\)Type: String  \nA token generated by AWS Firewall Manager when\
+    \ creating the rule in customer account\\. AWS Config ignores this parameter when\
+    \ customer creates this rule\\.\n\nfmsRemediationEnabled \\(Optional\\)Type: boolean\
+    \  \nIf true, AWS Firewall Manager will update non\\-compliant resources according\
+    \ to FMS policy\\. AWS Config ignores this parameter when customer creates this\
+    \ rule\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d277c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: FMS_WEBACL_RESOURCE_POLICY_CHECK
+  Name: fms-webacl-resource-policy-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\) Region
+  Description: Checks if the rule groups associate with the web ACL at the correct
+    priority\. The correct priority is decided by the rank of the rule groups in the
+    ruleGroups parameter\. When AWS Firewall Manager creates this rule, it assigns
+    the highest priority 0 followed by 1, 2, and so on\. The FMS policy owner specifies
+    the `ruleGroups` rank in the FMS policy and can optionally enable remediation\.
+  File: fms-webacl-rulegroup-association-check.md
+  FullDocumentation: "# fms\\-webacl\\-rulegroup\\-association\\-check<a name=\"fms-webacl-rulegroup-association-check\"\
+    ></a>\n\nChecks if the rule groups associate with the web ACL at the correct priority\\\
+    . The correct priority is decided by the rank of the rule groups in the ruleGroups\
+    \ parameter\\. When AWS Firewall Manager creates this rule, it assigns the highest\
+    \ priority 0 followed by 1, 2, and so on\\. The FMS policy owner specifies the\
+    \ `ruleGroups` rank in the FMS policy and can optionally enable remediation\\\
+    .\n\n**Identifier:** FMS\\_WEBACL\\_RULEGROUP\\_ASSOCIATION\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ Asia Pacific \\(Jakarta\\) Region\n\n**Parameters:**\n\nruleGroupsType: String\
+    \  \nComma\\-separated list of RuleGroupIds and WafOverrideAction pairs\\. \\\
+    (for example, ruleGroupId\\-1:NONE, ruleGroupId2:COUNT\\)\n\nfmsManagedToken \\\
+    (Optional\\)Type: String  \nA token generated by AWS Firewall Manager when creating\
+    \ the rule in customer account\\. AWS Config ignores this parameter when customer\
+    \ creates this rule\\.\n\nfmsRemediationEnabled \\(Optional\\)Type: boolean  \n\
+    If true, AWS Firewall Manager will update non\\-compliant resources according\
+    \ to FMS policy\\. AWS Config ignores this parameter when customer creates this\
+    \ rule\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d279c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: FMS_WEBACL_RULEGROUP_ASSOCIATION_CHECK
+  Name: fms-webacl-rulegroup-association-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon FSx File Systems are protected by a backup plan\.
+    The rule is NON\_COMPLIANT if the Amazon FSx File System is not covered by a backup
+    plan\.
+  File: fsx-resources-protected-by-backup-plan.md
+  FullDocumentation: "# fsx\\-resources\\-protected\\-by\\-backup\\-plan<a name=\"\
+    fsx-resources-protected-by-backup-plan\"></a>\n\nChecks if Amazon FSx File Systems\
+    \ are protected by a backup plan\\. The rule is NON\\_COMPLIANT if the Amazon\
+    \ FSx File System is not covered by a backup plan\\. \n\n**Identifier:** FSX\\\
+    _RESOURCES\\_PROTECTED\\_BY\\_BACKUP\\_PLAN\n\n**Trigger type:** Periodic\n\n\
+    **AWS Region:** All supported AWS regions except Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nresourceTags\
+    \ \\(Optional\\)Type: String  \nTags of Amazon FSx File Systems for the rule to\
+    \ check, in JSON format\\.\n\nresourceId \\(Optional\\)Type: String  \nID of the\
+    \ Amazon FSx File System for the rule to check\\.\n\ncrossRegionList \\(Optional\\\
+    )Type: String  \nComma\\-separated list of destination regions for the cross\\\
+    -region backup copy to be kept\n\ncrossAccountList \\(Optional\\)Type: String\
+    \  \nComma\\-separated list of destination accounts for cross\\-account backup\
+    \ copy to be kept\n\nmaxRetentionDays \\(Optional\\)Type: int  \nThe maximum retention\
+    \ period in days for the Backup Vault Lock\n\nminRetentionDays \\(Optional\\)Type:\
+    \ int  \nThe minimum retention period in days for the Backup Vault Lock\n\nbackupVaultLockCheck\
+    \ \\(Optional\\)Type: String  \nAccepted values: 'True' or 'False'\\. Enter 'True'\
+    \ for the rule to check if the resource is backed up in a locked vault\n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d281c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: FSX_RESOURCES_PROTECTED_BY_BACKUP_PLAN
+  Name: fsx-resources-protected-by-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe
+    \(Milan\), Middle East \(Bahrain\), Africa \(Cape Town\) Region
+  Description: Checks if Amazon GuardDuty is enabled in your AWS account and region\.
+    If you provide an AWS account for centralization, the rule evaluates the Amazon
+    GuardDuty results in the centralized account\. The rule is COMPLIANT when Amazon
+    GuardDuty is enabled\.
+  File: guardduty-enabled-centralized.md
+  FullDocumentation: "# guardduty\\-enabled\\-centralized<a name=\"guardduty-enabled-centralized\"\
+    ></a>\n\nChecks if Amazon GuardDuty is enabled in your AWS account and region\\\
+    . If you provide an AWS account for centralization, the rule evaluates the Amazon\
+    \ GuardDuty results in the centralized account\\. The rule is COMPLIANT when Amazon\
+    \ GuardDuty is enabled\\.\n\n**Identifier:** GUARDDUTY\\_ENABLED\\_CENTRALIZED\n\
+    \n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Middle\
+    \ East \\(Bahrain\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nCentralMonitoringAccount\
+    \ \\(Optional\\)Type: String  \nComma separated list of AWS Accounts \\(12\\-digit\\\
+    ) where Amazon GuardDuty results are allowed to be centralized\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d283c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: GUARDDUTY_ENABLED_CENTRALIZED
+  Name: guardduty-enabled-centralized
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe
+    \(Milan\), Middle East \(Bahrain\), Africa \(Cape Town\) Region
+  Description: Checks whether Amazon GuardDuty has findings that are non archived\.
+    The rule is NON\_COMPLIANT if Amazon GuardDuty has non archived low/medium/high
+    severity findings older than the specified number in the daysLowSev/daysMediumSev/`daysHighSev`
+    parameter\.
+  File: guardduty-non-archived-findings.md
+  FullDocumentation: "# guardduty\\-non\\-archived\\-findings<a name=\"guardduty-non-archived-findings\"\
+    ></a>\n\nChecks whether Amazon GuardDuty has findings that are non archived\\\
+    . The rule is NON\\_COMPLIANT if Amazon GuardDuty has non archived low/medium/high\
+    \ severity findings older than the specified number in the daysLowSev/daysMediumSev/`daysHighSev`\
+    \ parameter\\. \n\n**Identifier:** GUARDDUTY\\_NON\\_ARCHIVED\\_FINDINGS\n\n**Trigger\
+    \ type:** Periodic\n\n**AWS Region:** All supported AWS regions except China \\\
+    (Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), Asia Pacific \\\
+    (Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Middle East \\(Bahrain\\\
+    ), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\ndaysLowSev \\(Optional\\\
+    )Type: intDefault: 30  \nThe number of days Amazon GuardDuty low severity findings\
+    \ are allowed to stay non archived\\. The default is 30 days\\.\n\ndaysMediumSev\
+    \ \\(Optional\\)Type: intDefault: 7  \nThe number of days Amazon GuardDuty medium\
+    \ severity findings are allowed to stay non archived\\. The default is 7 days\\\
+    .\n\ndaysHighSev \\(Optional\\)Type: intDefault: 1  \nThe number of days Amazon\
+    \ GuardDuty high severity findings are allowed to stay non archived\\. The default\
+    \ is 1 day\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d285c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: GUARDDUTY_NON_ARCHIVED_FINDINGS
+  Name: guardduty-non-archived-findings
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks that the managed AWS Identity and Access Management \(IAM\)
+    policies that you create do not allow blocked actions on all AWS KMS keys\. The
+    rule is NON\_COMPLIANT if any blocked action is allowed on all AWS KMS keys by
+    the managed IAM policy\.
+  File: iam-customer-policy-blocked-kms-actions.md
+  FullDocumentation: "# iam\\-customer\\-policy\\-blocked\\-kms\\-actions<a name=\"\
+    iam-customer-policy-blocked-kms-actions\"></a>\n\nChecks that the managed AWS\
+    \ Identity and Access Management \\(IAM\\) policies that you create do not allow\
+    \ blocked actions on all AWS KMS keys\\. The rule is NON\\_COMPLIANT if any blocked\
+    \ action is allowed on all AWS KMS keys by the managed IAM policy\\. \n\n**Identifier:**\
+    \ IAM\\_CUSTOMER\\_POLICY\\_BLOCKED\\_KMS\\_ACTIONS\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nblockedActionsPatternsType:\
+    \ CSV  \nComma\\-separated list of blocked KMS action patterns, for example, kms:\\\
+    *, kms:Decrypt, kms:ReEncrypt\\*\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d287c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: IAM_CUSTOMER_POLICY_BLOCKED_KMS_ACTIONS
+  Name: iam-customer-policy-blocked-kms-actions
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks whether IAM groups have at least one IAM user\.
+  File: iam-group-has-users-check.md
+  FullDocumentation: "# iam\\-group\\-has\\-users\\-check<a name=\"iam-group-has-users-check\"\
+    ></a>\n\nChecks whether IAM groups have at least one IAM user\\. \n\n**Identifier:**\
+    \ IAM\\_GROUP\\_HAS\\_USERS\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7d289c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_GROUP_HAS_USERS_CHECK
+  Name: iam-group-has-users-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks that the inline policies attached to your IAM users, roles,
+    and groups do not allow blocked actions on all AWS Key Management Service \(KMS\)
+    keys\. The rule is NON\_COMPLIANT if any blocked action is allowed on all KMS
+    keys in an inline policy\.
+  File: iam-inline-policy-blocked-kms-actions.md
+  FullDocumentation: "# iam\\-inline\\-policy\\-blocked\\-kms\\-actions<a name=\"\
+    iam-inline-policy-blocked-kms-actions\"></a>\n\nChecks that the inline policies\
+    \ attached to your IAM users, roles, and groups do not allow blocked actions on\
+    \ all AWS Key Management Service \\(KMS\\) keys\\. The rule is NON\\_COMPLIANT\
+    \ if any blocked action is allowed on all KMS keys in an inline policy\\. \n\n\
+    **Identifier:** IAM\\_INLINE\\_POLICY\\_BLOCKED\\_KMS\\_ACTIONS\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\n\
+    blockedActionsPatternsType: CSV  \nComma\\-separated list of blocked KMS action\
+    \ patterns, for example, kms:\\*, kms:Decrypt, kms:ReEncrypt\\*\\.\n\nexcludeRoleByManagementAccount\
+    \ \\(Optional\\)Type: boolean  \nExclude a role if it is only assumable by organization\
+    \ management account\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d291c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_INLINE_POLICY_BLOCKED_KMS_ACTIONS
+  Name: iam-inline-policy-blocked-kms-actions
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks that inline policy feature is not in use\. The rule is NON\_COMPLIANT
+    if an AWS Identity and Access Management \(IAM\) user, IAM role or IAM group has
+    any inline policy\.
+  File: iam-no-inline-policy-check.md
+  FullDocumentation: "# iam\\-no\\-inline\\-policy\\-check<a name=\"iam-no-inline-policy-check\"\
+    ></a>\n\nChecks that inline policy feature is not in use\\. The rule is NON\\\
+    _COMPLIANT if an AWS Identity and Access Management \\(IAM\\) user, IAM role or\
+    \ IAM group has any inline policy\\. \n\n**Identifier:** IAM\\_NO\\_INLINE\\_POLICY\\\
+    _CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d293c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_NO_INLINE_POLICY_CHECK
+  Name: iam-no-inline-policy-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: "Checks if the account password policy for IAM users meets the specified\
+    \ requirements indicated in the parameters\\. This rule is NON\\_COMPLIANT if\
+    \ the account password policy does not meet the specified requirements\\.\n\n\
+    **Note**  \nThe rule is marked as NON\\-COMPLIANT when default IAM password policy\
+    \ is used\\.\n\n**Important**  \nThe `true` and `false` values for the rule parameters\
+    \ are case\\-sensitive\\. If `true` is not provided in lowercase, it will be treated\
+    \ as `false.`"
+  File: iam-password-policy.md
+  FullDocumentation: "# iam\\-password\\-policy<a name=\"iam-password-policy\"></a>\n\
+    \nChecks if the account password policy for IAM users meets the specified requirements\
+    \ indicated in the parameters\\. This rule is NON\\_COMPLIANT if the account password\
+    \ policy does not meet the specified requirements\\.\n\n**Note**  \nThe rule is\
+    \ marked as NON\\-COMPLIANT when default IAM password policy is used\\.\n\n**Important**\
+    \  \nThe `true` and `false` values for the rule parameters are case\\-sensitive\\\
+    . If `true` is not provided in lowercase, it will be treated as `false.`\n\n**Identifier:**\
+    \ IAM\\_PASSWORD\\_POLICY\n\n**Trigger type:** Periodic\n\n**AWS Region:** All\
+    \ supported AWS regions\n\n**Parameters:**\n\nRequireUppercaseCharacters \\(Optional\\\
+    )Type: booleanDefault: true  \nRequire at least one uppercase character in password\\\
+    .\n\nRequireLowercaseCharacters \\(Optional\\)Type: booleanDefault: true  \nRequire\
+    \ at least one lowercase character in password\\.\n\nRequireSymbols \\(Optional\\\
+    )Type: booleanDefault: true  \nRequire at least one symbol in password\\.\n\n\
+    RequireNumbers \\(Optional\\)Type: booleanDefault: true  \nRequire at least one\
+    \ number in password\\.\n\nMinimumPasswordLength \\(Optional\\)Type: intDefault:\
+    \ 14  \nPassword minimum length\\.\n\nPasswordReusePrevention \\(Optional\\)Type:\
+    \ intDefault: 24  \nNumber of passwords before allowing reuse\\.\n\nMaxPasswordAge\
+    \ \\(Optional\\)Type: intDefault: 90  \nNumber of days before password expiration\\\
+    .\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d295c19\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_PASSWORD_POLICY
+  Name: iam-password-policy
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks if for each IAM resource, a policy ARN in the input parameter
+    is attached to the IAM resource\. The rule is NON\_COMPLIANT if the policy ARN
+    is attached to the IAM resource\. AWS Config marks the resource as COMPLIANT if
+    the IAM resource is part of the `exceptionList` parameter irrespective of the
+    presence of the policy ARN\.
+  File: iam-policy-blacklisted-check.md
+  FullDocumentation: "# iam\\-policy\\-blacklisted\\-check<a name=\"iam-policy-blacklisted-check\"\
+    ></a>\n\nChecks if for each IAM resource, a policy ARN in the input parameter\
+    \ is attached to the IAM resource\\. The rule is NON\\_COMPLIANT if the policy\
+    \ ARN is attached to the IAM resource\\. AWS Config marks the resource as COMPLIANT\
+    \ if the IAM resource is part of the `exceptionList` parameter irrespective of\
+    \ the presence of the policy ARN\\.\n\n**Identifier:** IAM\\_POLICY\\_BLACKLISTED\\\
+    _CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions\n\n**Parameters:**\n\npolicyArnsType: CSVDefault: arn:aws:iam::aws:policy/AdministratorAccess\
+    \  \nComma\\-separated list of IAM policy arns which should not be attached to\
+    \ any IAM entity\\.\n\nexceptionList \\(Optional\\)Type: CSV  \nComma\\-separated\
+    \ list IAM users, groups, or roles that are exempt from this rule\\. For example,\
+    \ users:\\[user1;user2\\], groups:\\[group1;group2\\], roles:\\[role1;role2;role3\\\
+    ]\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d297c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_POLICY_BLACKLISTED_CHECK
+  Name: iam-policy-blacklisted-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether the IAM policy ARN is attached to an IAM user, or a
+    group with one or more IAM users, or an IAM role with one or more trusted entity\.
+  File: iam-policy-in-use.md
+  FullDocumentation: "# iam\\-policy\\-in\\-use<a name=\"iam-policy-in-use\"></a>\n\
+    \nChecks whether the IAM policy ARN is attached to an IAM user, or a group with\
+    \ one or more IAM users, or an IAM role with one or more trusted entity\\. \n\n\
+    **Identifier:** IAM\\_POLICY\\_IN\\_USE\n\n**Trigger type:** Periodic\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \npolicyARNType: String  \nAn IAM policy ARN to be checked\\.\n\npolicyUsageType\
+    \ \\(Optional\\)Type: String  \nSpecify whether you expect the policy to be attached\
+    \ to an IAM user, group or role\\. Valid values are IAM\\_USER, IAM\\_GROUP, IAM\\\
+    _ROLE, or ANY\\. Default value is ANY\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d299c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: IAM_POLICY_IN_USE
+  Name: iam-policy-in-use
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: 'Checks the IAM policies that you create for Allow statements that
+    grant permissions to all actions on all resources\. The rule is NON\_COMPLIANT
+    if any policy statement includes "Effect": "Allow" with "Action": "\*" over "Resource":
+    "\*"\.
+
+
+    The following policy is NON\_COMPLIANT:
+
+
+    ```
+
+    "Statement": [
+
+    {
+
+    "Sid": "VisualEditor",
+
+    "Effect": "Allow",
+
+    "Action": "*",
+
+    "Resource": "*"
+
+    }
+
+    ```
+
+
+    The following policy is COMPLIANT:
+
+
+    ```
+
+    "Statement": [
+
+    {
+
+    "Sid": "VisualEditor",
+
+    "Effect": "Allow",
+
+    "Action": "service:*",
+
+    "Resource": "*"
+
+    }
+
+    ```
+
+
+    This rule checks only the IAM policies that you create\. It does not check IAM
+    Managed Policies\. When you enable the rule, this rule checks all of the customer
+    managed policies in your account, and all new policies that you create\.'
+  File: iam-policy-no-statements-with-admin-access.md
+  FullDocumentation: "# iam\\-policy\\-no\\-statements\\-with\\-admin\\-access<a name=\"\
+    iam-policy-no-statements-with-admin-access\"></a>\n\nChecks the IAM policies that\
+    \ you create for Allow statements that grant permissions to all actions on all\
+    \ resources\\. The rule is NON\\_COMPLIANT if any policy statement includes \"\
+    Effect\": \"Allow\" with \"Action\": \"\\*\" over \"Resource\": \"\\*\"\\.\n\n\
+    The following policy is NON\\_COMPLIANT:\n\n```\n\"Statement\": [\n{\n\"Sid\"\
+    : \"VisualEditor\",\n\"Effect\": \"Allow\",\n\"Action\": \"*\",\n\"Resource\"\
+    : \"*\"\n}\n```\n\nThe following policy is COMPLIANT:\n\n```\n\"Statement\": [\n\
+    {\n\"Sid\": \"VisualEditor\",\n\"Effect\": \"Allow\",\n\"Action\": \"service:*\"\
+    ,\n\"Resource\": \"*\"\n}\n```\n\nThis rule checks only the IAM policies that\
+    \ you create\\. It does not check IAM Managed Policies\\. When you enable the\
+    \ rule, this rule checks all of the customer managed policies in your account,\
+    \ and all new policies that you create\\.\n\n**Identifier:** IAM\\_POLICY\\_NO\\\
+    _STATEMENTS\\_WITH\\_ADMIN\\_ACCESS\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7d301c25\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS
+  Name: iam-policy-no-statements-with-admin-access
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: "Checks if AWS Identity and Access Management \\(IAM\\) policies grant\
+    \ permissions to all actions on individual AWS resources\\. The rule is NON\\\
+    _COMPLIANT if the managed IAM policy allows full access to at least 1 AWS service\\\
+    . \n\n**Note**  \nThis rule only evaluates managed policies\\. This rule does\
+    \ NOT evaluate inline policies\\. For more information on the difference, see\
+    \ [Managed policies and inline policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html)\
+    \ in the IAM User Guide\\."
+  File: iam-policy-no-statements-with-full-access.md
+  FullDocumentation: "# iam\\-policy\\-no\\-statements\\-with\\-full\\-access<a name=\"\
+    iam-policy-no-statements-with-full-access\"></a>\n\nChecks if AWS Identity and\
+    \ Access Management \\(IAM\\) policies grant permissions to all actions on individual\
+    \ AWS resources\\. The rule is NON\\_COMPLIANT if the managed IAM policy allows\
+    \ full access to at least 1 AWS service\\. \n\n**Note**  \nThis rule only evaluates\
+    \ managed policies\\. This rule does NOT evaluate inline policies\\. For more\
+    \ information on the difference, see [Managed policies and inline policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html)\
+    \ in the IAM User Guide\\.\n\n**Identifier:** IAM\\_POLICY\\_NO\\_STATEMENTS\\\
+    _WITH\\_FULL\\_ACCESS\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except China \\(Beijing\\), China \\(Ningxia\\), AWS\
+    \ GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nexcludePermissionBoundaryPolicy\
+    \ \\(Optional\\)Type: boolean  \nBoolean flag to ignore evaluation of IAM policies\
+    \ if used only as a permission boundary\\. The IAM policy is evaluated when value\
+    \ is False\\. Default is False\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d303c17\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: IAM_POLICY_NO_STATEMENTS_WITH_FULL_ACCESS
+  Name: iam-policy-no-statements-with-full-access
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if all AWS managed policies specified in the list of managed
+    policies are attached to the AWS Identity and Access Management \(IAM\) role\.
+    The rule is non\-compliant if an AWS managed policy is not attached to the IAM
+    role\.
+  File: iam-role-managed-policy-check.md
+  FullDocumentation: "# iam\\-role\\-managed\\-policy\\-check<a name=\"iam-role-managed-policy-check\"\
+    ></a>\n\nChecks if all AWS managed policies specified in the list of managed policies\
+    \ are attached to the AWS Identity and Access Management \\(IAM\\) role\\. The\
+    \ rule is non\\-compliant if an AWS managed policy is not attached to the IAM\
+    \ role\\. \n\n**Identifier:** IAM\\_ROLE\\_MANAGED\\_POLICY\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\nmanagedPolicyArnsType: CSV  \nComma\\-separated list of AWS\
+    \ managed policy ARNs\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d305c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_ROLE_MANAGED_POLICY_CHECK
+  Name: iam-role-managed-policy-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks if the root user access key is available\. The rule is COMPLIANT
+    if the user access key does not exist\. Otherwise, NON\_COMPLIANT\.
+  File: iam-root-access-key-check.md
+  FullDocumentation: "# iam\\-root\\-access\\-key\\-check<a name=\"iam-root-access-key-check\"\
+    ></a>\n\nChecks if the root user access key is available\\. The rule is COMPLIANT\
+    \ if the user access key does not exist\\. Otherwise, NON\\_COMPLIANT\\.\n\n**Identifier:**\
+    \ IAM\\_ROOT\\_ACCESS\\_KEY\\_CHECK\n\n**Trigger type:** Periodic\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\\
+    (Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d307c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_ROOT_ACCESS_KEY_CHECK
+  Name: iam-root-access-key-check
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks whether IAM users are members of at least one IAM group\.
+  File: iam-user-group-membership-check.md
+  FullDocumentation: "# iam\\-user\\-group\\-membership\\-check<a name=\"iam-user-group-membership-check\"\
+    ></a>\n\nChecks whether IAM users are members of at least one IAM group\\. \n\n\
+    **Identifier:** IAM\\_USER\\_GROUP\\_MEMBERSHIP\\_CHECK\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    groupNames \\(Optional\\)Type: String  \nComma\\-separated list of IAM groups\
+    \ in which IAM users must be members\\.  \nThis rule does not support group names\
+    \ with commas\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d309c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_USER_GROUP_MEMBERSHIP_CHECK
+  Name: iam-user-group-membership-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks whether the AWS Identity and Access Management users have multi\-factor
+    authentication \(MFA\) enabled\.
+  File: iam-user-mfa-enabled.md
+  FullDocumentation: "# iam\\-user\\-mfa\\-enabled<a name=\"iam-user-mfa-enabled\"\
+    ></a>\n\nChecks whether the AWS Identity and Access Management users have multi\\\
+    -factor authentication \\(MFA\\) enabled\\. \n\n**Identifier:** IAM\\_USER\\_MFA\\\
+    _ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d311c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_USER_MFA_ENABLED
+  Name: iam-user-mfa-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks that none of your IAM users have policies attached\. IAM users
+    must inherit permissions from IAM groups or roles\. The rule is NONCOMPLIANT if
+    there is at least one IAM user with policies attached\.
+  File: iam-user-no-policies-check.md
+  FullDocumentation: "# iam\\-user\\-no\\-policies\\-check<a name=\"iam-user-no-policies-check\"\
+    ></a>\n\nChecks that none of your IAM users have policies attached\\. IAM users\
+    \ must inherit permissions from IAM groups or roles\\. The rule is NONCOMPLIANT\
+    \ if there is at least one IAM user with policies attached\\.\n\n**Identifier:**\
+    \ IAM\\_USER\\_NO\\_POLICIES\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7d313c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_USER_NO_POLICIES_CHECK
+  Name: iam-user-no-policies-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: "Checks if your AWS Identity and Access Management \\(IAM\\) users\
+    \ have passwords or active access keys that have not been used within the specified\
+    \ number of days you provided\\. The rule is NON\\_COMPLIANT if there are inactive\
+    \ accounts not recently used\\.\n\n**Note**  \nRe\\-evaluating this rule within\
+    \ 4 hours of the first evaluation will have no effect on the results\\."
+  File: iam-user-unused-credentials-check.md
+  FullDocumentation: "# iam\\-user\\-unused\\-credentials\\-check<a name=\"iam-user-unused-credentials-check\"\
+    ></a>\n\nChecks if your AWS Identity and Access Management \\(IAM\\) users have\
+    \ passwords or active access keys that have not been used within the specified\
+    \ number of days you provided\\. The rule is NON\\_COMPLIANT if there are inactive\
+    \ accounts not recently used\\.\n\n**Note**  \nRe\\-evaluating this rule within\
+    \ 4 hours of the first evaluation will have no effect on the results\\.\n\n**Identifier:**\
+    \ IAM\\_USER\\_UNUSED\\_CREDENTIALS\\_CHECK\n\n**Trigger type:** Periodic\n\n\
+    **AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nmaxCredentialUsageAgeType:\
+    \ intDefault: 90  \nMaximum number of days a credential cannot be used\\. The\
+    \ default value is 90 days\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d315c17\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: IAM_USER_UNUSED_CREDENTIALS_CHECK
+  Name: iam-user-unused-credentials-check
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks that Internet gateways \(IGWs\) are only attached to an authorized
+    Amazon Virtual Private Cloud \(VPCs\)\. The rule is NON\_COMPLIANT if IGWs are
+    not attached to an authorized VPC\.
+  File: internet-gateway-authorized-vpc-only.md
+  FullDocumentation: "# internet\\-gateway\\-authorized\\-vpc\\-only<a name=\"internet-gateway-authorized-vpc-only\"\
+    ></a>\n\nChecks that Internet gateways \\(IGWs\\) are only attached to an authorized\
+    \ Amazon Virtual Private Cloud \\(VPCs\\)\\. The rule is NON\\_COMPLIANT if IGWs\
+    \ are not attached to an authorized VPC\\. \n\n**Identifier:** INTERNET\\_GATEWAY\\\
+    _AUTHORIZED\\_VPC\\_ONLY\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\\
+    (Osaka\\) Region\n\n**Parameters:**\n\nAuthorizedVpcIds \\(Optional\\)Type: String\
+    \  \nComma\\-separated list of the authorized VPC IDs with attached IGWs\\. If\
+    \ parameter is not provided all attached IGWs will be NON\\_COMPLIANT\\.\n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7d321c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: INTERNET_GATEWAY_AUTHORIZED_VPC_ONLY
+  Name: internet-gateway-authorized-vpc-only
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if Amazon Kinesis streams are encrypted at rest with server\-side
+    encryption\. The rule is NON\_COMPLIANT for a Kinesis stream if 'StreamEncryption'
+    is not present\.
+  File: kinesis-stream-encrypted.md
+  FullDocumentation: "# kinesis\\-stream\\-encrypted<a name=\"kinesis-stream-encrypted\"\
+    ></a>\n\nChecks if Amazon Kinesis streams are encrypted at rest with server\\\
+    -side encryption\\. The rule is NON\\_COMPLIANT for a Kinesis stream if 'StreamEncryption'\
+    \ is not present\\. \n\n**Identifier:** KINESIS\\_STREAM\\_ENCRYPTED\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d323c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: KINESIS_STREAM_ENCRYPTED
+  Name: kinesis-stream-encrypted
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\) Region
+  Description: Checks if AWS KMS keys \(KMS keys\) are not scheduled for deletion
+    in AWS Key Management Service \(AWS KMS\)\. The rule is NON\_COMPLAINT if KMS
+    keys are scheduled for deletion\.
+  File: kms-cmk-not-scheduled-for-deletion.md
+  FullDocumentation: "# kms\\-cmk\\-not\\-scheduled\\-for\\-deletion<a name=\"kms-cmk-not-scheduled-for-deletion\"\
+    ></a>\n\nChecks if AWS KMS keys \\(KMS keys\\) are not scheduled for deletion\
+    \ in AWS Key Management Service \\(AWS KMS\\)\\. The rule is NON\\_COMPLAINT if\
+    \ KMS keys are scheduled for deletion\\. \n\n**Identifier:** KMS\\_CMK\\_NOT\\\
+    _SCHEDULED\\_FOR\\_DELETION\n\n**Trigger type:** Periodic\n\n**AWS Region:** All\
+    \ supported AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\\
+    ), Europe \\(Milan\\) Region\n\n**Parameters:**\n\nkmsKeyIds \\(Optional\\)Type:\
+    \ String  \n\\(Optional\\) Comma\\-separated list of specific customer managed\
+    \ key IDs not to be scheduled for deletion\\. If you do not specify any keys,\
+    \ the rule checks all the keys\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d325c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: KMS_CMK_NOT_SCHEDULED_FOR_DELETION
+  Name: kms-cmk-not-scheduled-for-deletion
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Ningxia\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks whether the AWS Lambda function is configured with function\-level
+    concurrent execution limit\. The rule is NON\_COMPLIANT if the Lambda function
+    is not configured with function\-level concurrent execution limit\.
+  File: lambda-concurrency-check.md
+  FullDocumentation: "# lambda\\-concurrency\\-check<a name=\"lambda-concurrency-check\"\
+    ></a>\n\nChecks whether the AWS Lambda function is configured with function\\\
+    -level concurrent execution limit\\. The rule is NON\\_COMPLIANT if the Lambda\
+    \ function is not configured with function\\-level concurrent execution limit\\\
+    . \n\n**Identifier:** LAMBDA\\_CONCURRENCY\\_CHECK\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except China \\(Ningxia\\\
+    ), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\
+    \nConcurrencyLimitLow \\(Optional\\)Type: String  \nMinimum concurrency execution\
+    \ limit\n\nConcurrencyLimitHigh \\(Optional\\)Type: String  \nMaximum concurrency\
+    \ execution limit\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d327c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: LAMBDA_CONCURRENCY_CHECK
+  Name: lambda-concurrency-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Ningxia\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks whether an AWS Lambda function is configured with a dead\-letter
+    queue\. The rule is NON\_COMPLIANT if the Lambda function is not configured with
+    a dead\-letter queue\.
+  File: lambda-dlq-check.md
+  FullDocumentation: "# lambda\\-dlq\\-check<a name=\"lambda-dlq-check\"></a>\n\n\
+    Checks whether an AWS Lambda function is configured with a dead\\-letter queue\\\
+    . The rule is NON\\_COMPLIANT if the Lambda function is not configured with a\
+    \ dead\\-letter queue\\. \n\n**Identifier:** LAMBDA\\_DLQ\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Ningxia\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\ndlqArns \\(Optional\\)Type: String  \nComma\\-separated list\
+    \ of Amazon SQS and Amazon SNS ARNs that must be configured as the Lambda function\
+    \ dead\\-letter queue target\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d329c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: LAMBDA_DLQ_CHECK
+  Name: lambda-dlq-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Ningxia\), Asia Pacific \(Osaka\)
+    Region
+  Description: Checks if the AWS Lambda function policy attached to the Lambda resource
+    prohibits public access\. If the Lambda function policy allows public access it
+    is NON\_COMPLIANT\.
+  File: lambda-function-public-access-prohibited.md
+  FullDocumentation: "# lambda\\-function\\-public\\-access\\-prohibited<a name=\"\
+    lambda-function-public-access-prohibited\"></a>\n\nChecks if the AWS Lambda function\
+    \ policy attached to the Lambda resource prohibits public access\\. If the Lambda\
+    \ function policy allows public access it is NON\\_COMPLIANT\\.\n\n**Identifier:**\
+    \ LAMBDA\\_FUNCTION\\_PUBLIC\\_ACCESS\\_PROHIBITED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except China \\(Ningxia\\\
+    ), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d331c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: LAMBDA_FUNCTION_PUBLIC_ACCESS_PROHIBITED
+  Name: lambda-function-public-access-prohibited
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Ningxia\), Asia Pacific \(Osaka\)
+    Region
+  Description: Checks that the AWS Lambda function settings for runtime, role, timeout,
+    and memory size match the expected values\. The rule ignores functions with the
+    'Image' package type\.
+  File: lambda-function-settings-check.md
+  FullDocumentation: "# lambda\\-function\\-settings\\-check<a name=\"lambda-function-settings-check\"\
+    ></a>\n\nChecks that the AWS Lambda function settings for runtime, role, timeout,\
+    \ and memory size match the expected values\\. The rule ignores functions with\
+    \ the 'Image' package type\\.\n\n**Identifier:** LAMBDA\\_FUNCTION\\_SETTINGS\\\
+    _CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except China \\(Ningxia\\), Asia Pacific \\(Osaka\\) Region\n\n\
+    **Parameters:**\n\nruntimeType: CSV  \nComma\\-separated list of AWS Lambda runtime\
+    \ values\n\nrole \\(Optional\\)Type: String  \nName or ARN of the AWS Lambda execution\
+    \ role\n\ntimeout \\(Optional\\)Type: intDefault: 3  \nAWS Lambda function timeout\
+    \ in seconds\n\nmemorySize \\(Optional\\)Type: intDefault: 128  \nAWS Lambda function\
+    \ size in megabytes\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d333c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: LAMBDA_FUNCTION_SETTINGS_CHECK
+  Name: lambda-function-settings-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Ningxia\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks whether an AWS Lambda function is allowed access to an Amazon
+    Virtual Private Cloud\. The rule is NON\_COMPLIANT if the Lambda function is not
+    VPC enabled\.
+  File: lambda-inside-vpc.md
+  FullDocumentation: "# lambda\\-inside\\-vpc<a name=\"lambda-inside-vpc\"></a>\n\n\
+    Checks whether an AWS Lambda function is allowed access to an Amazon Virtual Private\
+    \ Cloud\\. The rule is NON\\_COMPLIANT if the Lambda function is not VPC enabled\\\
+    . \n\n**Identifier:** LAMBDA\\_INSIDE\\_VPC\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except China \\(Ningxia\\\
+    ), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\
+    \nsubnetIds \\(Optional\\)Type: String  \nComma\\-separated list of Subnet IDs\
+    \ that Lambda functions can be associated with\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d335c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: LAMBDA_INSIDE_VPC
+  Name: lambda-inside-vpc
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\) Region
+  Description: Checks if Lambda has more than 1 availability zone associated\. The
+    rule is NON\_COMPLIANT if only 1 availability zone is associated with the Lambda
+    or the number of availability zones associated is less than number specified in
+    the optional parameter\.
+  File: lambda-vpc-multi-az-check.md
+  FullDocumentation: "# lambda\\-vpc\\-multi\\-az\\-check<a name=\"lambda-vpc-multi-az-check\"\
+    ></a>\n\nChecks if Lambda has more than 1 availability zone associated\\. The\
+    \ rule is NON\\_COMPLIANT if only 1 availability zone is associated with the Lambda\
+    \ or the number of availability zones associated is less than number specified\
+    \ in the optional parameter\\. \n\n**Identifier:** LAMBDA\\_VPC\\_MULTI\\_AZ\\\
+    _CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\navailabilityZones\
+    \ \\(Optional\\)Type: int  \nNumber of expected Availability zones\\.\n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d337c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: LAMBDA_VPC_MULTI_AZ_CHECK
+  Name: lambda-vpc-multi-az-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks whether AWS Multi\-Factor Authentication \(MFA\) is enabled
+    for all AWS Identity and Access Management \(IAM\) users that use a console password\.
+    The rule is compliant if MFA is enabled\.
+  File: mfa-enabled-for-iam-console-access.md
+  FullDocumentation: "# mfa\\-enabled\\-for\\-iam\\-console\\-access<a name=\"mfa-enabled-for-iam-console-access\"\
+    ></a>\n\nChecks whether AWS Multi\\-Factor Authentication \\(MFA\\) is enabled\
+    \ for all AWS Identity and Access Management \\(IAM\\) users that use a console\
+    \ password\\. The rule is compliant if MFA is enabled\\. \n\n**Identifier:** MFA\\\
+    _ENABLED\\_FOR\\_IAM\\_CONSOLE\\_ACCESS\n\n**Trigger type:** Periodic\n\n**AWS\
+    \ Region:** All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d339c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: MFA_ENABLED_FOR_IAM_CONSOLE_ACCESS
+  Name: mfa-enabled-for-iam-console-access
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks if there is at least one multi\-region AWS CloudTrail\. The
+    rule is NON\_COMPLIANT if the trails do not match input parameters\. The rule
+    is NON\_COMPLIANT if the `ExcludeManagementEventSources` field is not empty or
+    if AWS CloudTrail is configured to exclude management events such as AWS KMS events
+    or Amazon RDS Data API events\.
+  File: multi-region-cloudtrail-enabled.md
+  FullDocumentation: "# multi\\-region\\-cloudtrail\\-enabled<a name=\"multi-region-cloudtrail-enabled\"\
+    ></a>\n\nChecks if there is at least one multi\\-region AWS CloudTrail\\. The\
+    \ rule is NON\\_COMPLIANT if the trails do not match input parameters\\. The rule\
+    \ is NON\\_COMPLIANT if the `ExcludeManagementEventSources` field is not empty\
+    \ or if AWS CloudTrail is configured to exclude management events such as AWS\
+    \ KMS events or Amazon RDS Data API events\\.\n\n**Identifier:** MULTI\\_REGION\\\
+    _CLOUD\\_TRAIL\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All\
+    \ supported AWS regions\n\n**Parameters:**\n\ns3BucketName \\(Optional\\)Type:\
+    \ String  \nName of Amazon S3 bucket for AWS CloudTrail to deliver log files to\\\
+    .\n\nsnsTopicArn \\(Optional\\)Type: String  \nAmazon SNS topic ARN for AWS CloudTrail\
+    \ to use for notifications\\.\n\ncloudWatchLogsLogGroupArn \\(Optional\\)Type:\
+    \ String  \nAmazon CloudWatch log group ARN for AWS CloudTrail to send data to\\\
+    .\n\nincludeManagementEvents \\(Optional\\)Type: boolean  \nEvent selector to\
+    \ include management events for the AWS CloudTrail\\.\n\nreadWriteType \\(Optional\\\
+    )Type: String  \nType of events to record\\. Valid values are ReadOnly, WriteOnly\
+    \ and ALL\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d341c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: MULTI_REGION_CLOUD_TRAIL_ENABLED
+  Name: multi-region-cloudtrail-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks if default ports for SSH/RDP ingress traffic for network access
+    control lists \(NACLs\) is unrestricted\. The rule is NON\_COMPLIANT if a NACL
+    inbound entry allows a source TCP or UDP CIDR block for ports 22 or 3389\.
+  File: nacl-no-unrestricted-ssh-rdp.md
+  FullDocumentation: "# nacl\\-no\\-unrestricted\\-ssh\\-rdp<a name=\"nacl-no-unrestricted-ssh-rdp\"\
+    ></a>\n\nChecks if default ports for SSH/RDP ingress traffic for network access\
+    \ control lists \\(NACLs\\) is unrestricted\\. The rule is NON\\_COMPLIANT if\
+    \ a NACL inbound entry allows a source TCP or UDP CIDR block for ports 22 or 3389\\\
+    . \n\n**Identifier:** NACL\\_NO\\_UNRESTRICTED\\_SSH\\_RDP\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d343c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: NACL_NO_UNRESTRICTED_SSH_RDP
+  Name: nacl-no-unrestricted-ssh-rdp
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if a Stateless Network Firewall Rule Group contains rules\.
+    The rule is NON\_COMPLIANT if there are no rules in a Stateless Network Firewall
+    Rule Group\.
+  File: netfw-stateless-rule-group-not-empty.md
+  FullDocumentation: "# netfw\\-stateless\\-rule\\-group\\-not\\-empty<a name=\"netfw-stateless-rule-group-not-empty\"\
+    ></a>\n\nChecks if a Stateless Network Firewall Rule Group contains rules\\. The\
+    \ rule is NON\\_COMPLIANT if there are no rules in a Stateless Network Firewall\
+    \ Rule Group\\. \n\n**Identifier:** NETFW\\_STATELESS\\_RULE\\_GROUP\\_NOT\\_EMPTY\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d345c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: NETFW_STATELESS_RULE_GROUP_NOT_EMPTY
+  Name: netfw-stateless-rule-group-not-empty
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if there are public routes in the route table to an Internet
+    Gateway \(IGW\)\. The rule is NON\_COMPLIANT if a route to an IGW has a destination
+    CIDR block of '0\.0\.0\.0/0' or '::/0' or if a destination CIDR block does not
+    match the rule parameter\.
+  File: no-unrestricted-route-to-igw.md
+  FullDocumentation: "# no\\-unrestricted\\-route\\-to\\-igw<a name=\"no-unrestricted-route-to-igw\"\
+    ></a>\n\nChecks if there are public routes in the route table to an Internet Gateway\
+    \ \\(IGW\\)\\. The rule is NON\\_COMPLIANT if a route to an IGW has a destination\
+    \ CIDR block of '0\\.0\\.0\\.0/0' or '::/0' or if a destination CIDR block does\
+    \ not match the rule parameter\\. \n\n**Identifier:** NO\\_UNRESTRICTED\\_ROUTE\\\
+    _TO\\_IGW\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\\
+    (US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nrouteTableIds \\(Optional\\\
+    )Type: CSV  \nComma\\-separated list of route table IDs that can have routes to\
+    \ an Internet Gateway with a destination CIDR block of '0\\.0\\.0\\.0/0' or '::/0'\\\
+    .\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d347c15\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: NO_UNRESTRICTED_ROUTE_TO_IGW
+  Name: no-unrestricted-route-to-igw
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon OpenSearch Service domains have fine\-grained access
+    control enabled\. The rule is NON\_COMPLIANT if AdvancedSecurityOptions is not
+    enabled for the OpenSearch Service domain\.
+  File: opensearch-access-control-enabled.md
+  FullDocumentation: "# opensearch\\-access\\-control\\-enabled<a name=\"opensearch-access-control-enabled\"\
+    ></a>\n\nChecks if Amazon OpenSearch Service domains have fine\\-grained access\
+    \ control enabled\\. The rule is NON\\_COMPLIANT if AdvancedSecurityOptions is\
+    \ not enabled for the OpenSearch Service domain\\. \n\n**Identifier:** OPENSEARCH\\\
+    _ACCESS\\_CONTROL\\_ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7d349c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: OPENSEARCH_ACCESS_CONTROL_ENABLED
+  Name: opensearch-access-control-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon OpenSearch Service domains have audit logging enabled\.
+    The rule is NON\_COMPLIANT if an OpenSearch Service domain does not have audit
+    logging enabled\.
+  File: opensearch-audit-logging-enabled.md
+  FullDocumentation: "# opensearch\\-audit\\-logging\\-enabled<a name=\"opensearch-audit-logging-enabled\"\
+    ></a>\n\nChecks if Amazon OpenSearch Service domains have audit logging enabled\\\
+    . The rule is NON\\_COMPLIANT if an OpenSearch Service domain does not have audit\
+    \ logging enabled\\. \n\n**Identifier:** OPENSEARCH\\_AUDIT\\_LOGGING\\_ENABLED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape\
+    \ Town\\) Region\n\n**Parameters:**\n\ncloudWatchLogsLogGroupArnList \\(Optional\\\
+    )Type: CSV  \nComma\\-separated list of Amazon CloudWatch Logs log groups that\
+    \ should be configured for audit logs\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d351c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: OPENSEARCH_AUDIT_LOGGING_ENABLED
+  Name: opensearch-audit-logging-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon OpenSearch Service domains are configured with at
+    least three data nodes and zoneAwarenessEnabled is true\. The rule is NON\_COMPLIANT
+    for an OpenSearch domain if 'instanceCount' is less than 3 or 'zoneAwarenessEnabled'
+    is set to 'false'\.
+  File: opensearch-data-node-fault-tolerance.md
+  FullDocumentation: "# opensearch\\-data\\-node\\-fault\\-tolerance<a name=\"opensearch-data-node-fault-tolerance\"\
+    ></a>\n\nChecks if Amazon OpenSearch Service domains are configured with at least\
+    \ three data nodes and zoneAwarenessEnabled is true\\. The rule is NON\\_COMPLIANT\
+    \ for an OpenSearch domain if 'instanceCount' is less than 3 or 'zoneAwarenessEnabled'\
+    \ is set to 'false'\\. \n\n**Identifier:** OPENSEARCH\\_DATA\\_NODE\\_FAULT\\\
+    _TOLERANCE\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape\
+    \ Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d353c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: OPENSEARCH_DATA_NODE_FAULT_TOLERANCE
+  Name: opensearch-data-node-fault-tolerance
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon OpenSearch Service domains have encryption at rest
+    configuration enabled\. The rule is NON\_COMPLIANT if EncryptionAtRestOptions
+    field is not enabled\.
+  File: opensearch-encrypted-at-rest.md
+  FullDocumentation: "# opensearch\\-encrypted\\-at\\-rest<a name=\"opensearch-encrypted-at-rest\"\
+    ></a>\n\nChecks if Amazon OpenSearch Service domains have encryption at rest configuration\
+    \ enabled\\. The rule is NON\\_COMPLIANT if EncryptionAtRestOptions field is not\
+    \ enabled\\. \n\n**Identifier:** OPENSEARCH\\_ENCRYPTED\\_AT\\_REST\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d355c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: OPENSEARCH_ENCRYPTED_AT_REST
+  Name: opensearch-encrypted-at-rest
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks whether connections to OpenSearch domains are using HTTPS\.
+    The rule is NON\_COMPLIANT if the Amazon OpenSearch domain 'EnforceHTTPS' is not
+    'true' or is 'true' and 'TLSSecurityPolicy' is not in '`tlsPolicies`'\.
+  File: opensearch-https-required.md
+  FullDocumentation: "# opensearch\\-https\\-required<a name=\"opensearch-https-required\"\
+    ></a>\n\nChecks whether connections to OpenSearch domains are using HTTPS\\. The\
+    \ rule is NON\\_COMPLIANT if the Amazon OpenSearch domain 'EnforceHTTPS' is not\
+    \ 'true' or is 'true' and 'TLSSecurityPolicy' is not in '`tlsPolicies`'\\. \n\n\
+    **Identifier:** OPENSEARCH\\_HTTPS\\_REQUIRED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \ntlsPolicies \\(Optional\\)Type: CSV  \nComma\\-separated list of TLS security\
+    \ policies to check against the Amazon OpensSearch domain\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d357c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: OPENSEARCH_HTTPS_REQUIRED
+  Name: opensearch-https-required
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon OpenSearch Service domains are in an Amazon Virtual
+    Private Cloud \(VPC\)\. The rule is NON\_COMPLIANT if an OpenSearch Service domain
+    endpoint is public\.
+  File: opensearch-in-vpc-only.md
+  FullDocumentation: "# opensearch\\-in\\-vpc\\-only<a name=\"opensearch-in-vpc-only\"\
+    ></a>\n\nChecks if Amazon OpenSearch Service domains are in an Amazon Virtual\
+    \ Private Cloud \\(VPC\\)\\. The rule is NON\\_COMPLIANT if an OpenSearch Service\
+    \ domain endpoint is public\\. \n\n**Identifier:** OPENSEARCH\\_IN\\_VPC\\_ONLY\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape\
+    \ Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d359c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: OPENSEARCH_IN_VPC_ONLY
+  Name: opensearch-in-vpc-only
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon OpenSearch Service domains are configured to send
+    logs to Amazon CloudWatch Logs\. The rule is NON\_COMPLIANT if logging is not
+    configured\.
+  File: opensearch-logs-to-cloudwatch.md
+  FullDocumentation: "# opensearch\\-logs\\-to\\-cloudwatch<a name=\"opensearch-logs-to-cloudwatch\"\
+    ></a>\n\nChecks if Amazon OpenSearch Service domains are configured to send logs\
+    \ to Amazon CloudWatch Logs\\. The rule is NON\\_COMPLIANT if logging is not configured\\\
+    . \n\n**Identifier:** OPENSEARCH\\_LOGS\\_TO\\_CLOUDWATCH\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except Asia\
+    \ Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nlogTypes \\(Optional\\)Type: CSV  \nComma\\-separated list of logs that are\
+    \ enabled\\. Valid values are 'search', 'index', 'error'\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d361c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: OPENSEARCH_LOGS_TO_CLOUDWATCH
+  Name: opensearch-logs-to-cloudwatch
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Check that Amazon OpenSearch Service nodes are encrypted end to end\.
+    The rule is NON\_COMPLIANT if the node\-to\-node encryption is not enabled on
+    the domain
+  File: opensearch-node-to-node-encryption-check.md
+  FullDocumentation: "# opensearch\\-node\\-to\\-node\\-encryption\\-check<a name=\"\
+    opensearch-node-to-node-encryption-check\"></a>\n\nCheck that Amazon OpenSearch\
+    \ Service nodes are encrypted end to end\\. The rule is NON\\_COMPLIANT if the\
+    \ node\\-to\\-node encryption is not enabled on the domain \n\n**Identifier:**\
+    \ OPENSEARCH\\_NODE\\_TO\\_NODE\\_ENCRYPTION\\_CHECK\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d363c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: OPENSEARCH_NODE_TO_NODE_ENCRYPTION_CHECK
+  Name: opensearch-node-to-node-encryption-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if Amazon Relational Database Service \(RDS\) database instances
+    are configured for automatic minor version upgrades\. The rule is NON\_COMPLIANT
+    if the value of 'autoMinorVersionUpgrade' is false\.
+  File: rds-automatic-minor-version-upgrade-enabled.md
+  FullDocumentation: "# rds\\-automatic\\-minor\\-version\\-upgrade\\-enabled<a name=\"\
+    rds-automatic-minor-version-upgrade-enabled\"></a>\n\nChecks if Amazon Relational\
+    \ Database Service \\(RDS\\) database instances are configured for automatic minor\
+    \ version upgrades\\. The rule is NON\\_COMPLIANT if the value of 'autoMinorVersionUpgrade'\
+    \ is false\\. \n\n**Identifier:** RDS\\_AUTOMATIC\\_MINOR\\_VERSION\\_UPGRADE\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\\
+    (US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d365c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_AUTOMATIC_MINOR_VERSION_UPGRADE_ENABLED
+  Name: rds-automatic-minor-version-upgrade-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Middle East \(Bahrain\), South America
+    \(Sao Paulo\) Region
+  Description: Checks if an Amazon Relational Database Service \(Amazon RDS\) database
+    cluster has changed the admin username from its default value\. The rule is NON\_COMPLIANT
+    if the admin username is set to the default value\.
+  File: rds-cluster-default-admin-check.md
+  FullDocumentation: "# rds\\-cluster\\-default\\-admin\\-check<a name=\"rds-cluster-default-admin-check\"\
+    ></a>\n\nChecks if an Amazon Relational Database Service \\(Amazon RDS\\) database\
+    \ cluster has changed the admin username from its default value\\. The rule is\
+    \ NON\\_COMPLIANT if the admin username is set to the default value\\. \n\n**Identifier:**\
+    \ RDS\\_CLUSTER\\_DEFAULT\\_ADMIN\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except Middle East \\(Bahrain\\),\
+    \ South America \\(Sao Paulo\\) Region\n\n**Parameters:**\n\nvalidAdminUserNames\
+    \ \\(Optional\\)Type: CSV  \nComma\\-separated list of admin username\\(s\\) that\
+    \ Amazon RDS clusters can use\\. Cannot include 'postgres' or 'admin' as valid\
+    \ username\\(s\\) as these are default values\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d367c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_CLUSTER_DEFAULT_ADMIN_CHECK
+  Name: rds-cluster-default-admin-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Middle East \(Bahrain\), South
+    America \(Sao Paulo\) Region
+  Description: Checks if an Amazon Relational Database Service \(Amazon RDS\) cluster
+    has deletion protection enabled\. This rule is NON\_COMPLIANT if an RDS cluster
+    does not have deletion protection enabled\.
+  File: rds-cluster-deletion-protection-enabled.md
+  FullDocumentation: "# rds\\-cluster\\-deletion\\-protection\\-enabled<a name=\"\
+    rds-cluster-deletion-protection-enabled\"></a>\n\nChecks if an Amazon Relational\
+    \ Database Service \\(Amazon RDS\\) cluster has deletion protection enabled\\\
+    . This rule is NON\\_COMPLIANT if an RDS cluster does not have deletion protection\
+    \ enabled\\. \n\n**Identifier:** RDS\\_CLUSTER\\_DELETION\\_PROTECTION\\_ENABLED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except China \\(Beijing\\), China \\(Ningxia\\), Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\), Middle East \\(Bahrain\\), South America \\(Sao Paulo\\\
+    ) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d369c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: RDS_CLUSTER_DELETION_PROTECTION_ENABLED
+  Name: rds-cluster-deletion-protection-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\), Middle East \(Bahrain\), South America \(Sao Paulo\) Region
+  Description: Checks if an Amazon RDS Cluster has AWS Identity and Access Management
+    \(IAM\) authentication enabled\. The rule is NON\_COMPLIANT if an RDS Cluster
+    does not have IAM authentication enabled\.
+  File: rds-cluster-iam-authentication-enabled.md
+  FullDocumentation: "# rds\\-cluster\\-iam\\-authentication\\-enabled<a name=\"rds-cluster-iam-authentication-enabled\"\
+    ></a>\n\nChecks if an Amazon RDS Cluster has AWS Identity and Access Management\
+    \ \\(IAM\\) authentication enabled\\. The rule is NON\\_COMPLIANT if an RDS Cluster\
+    \ does not have IAM authentication enabled\\. \n\n**Identifier:** RDS\\_CLUSTER\\\
+    _IAM\\_AUTHENTICATION\\_ENABLED\n\n**Trigger type:** Configuration changes\n\n\
+    **AWS Region:** All supported AWS regions except China \\(Beijing\\), China \\\
+    (Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Middle East \\(Bahrain\\),\
+    \ South America \\(Sao Paulo\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d371c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_CLUSTER_IAM_AUTHENTICATION_ENABLED
+  Name: rds-cluster-iam-authentication-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\), Middle East \(Bahrain\), South America \(Sao Paulo\) Region
+  Description: Checks if Multi\-AZ replication is enabled on Amazon Aurora and Hermes
+    clusters managed by Amazon Relational Database Service \(Amazon RDS\)\. This rule
+    is NON\_COMPLIANT if an Amazon RDS instance is not configured with Multi\-AZ\.
+  File: rds-cluster-multi-az-enabled.md
+  FullDocumentation: "# rds\\-cluster\\-multi\\-az\\-enabled<a name=\"rds-cluster-multi-az-enabled\"\
+    ></a>\n\nChecks if Multi\\-AZ replication is enabled on Amazon Aurora and Hermes\
+    \ clusters managed by Amazon Relational Database Service \\(Amazon RDS\\)\\. This\
+    \ rule is NON\\_COMPLIANT if an Amazon RDS instance is not configured with Multi\\\
+    -AZ\\. \n\n**Identifier:** RDS\\_CLUSTER\\_MULTI\\_AZ\\_ENABLED\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except China\
+    \ \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud\
+    \ \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Middle\
+    \ East \\(Bahrain\\), South America \\(Sao Paulo\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d373c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+  Name: rds-cluster-multi-az-enabled
+  TriggerType: Configuration changes
+- AWSRegion: Only available in Europe \(Ireland\), South America \(Sao Paulo\), US
+    East \(N\. Virginia\), Asia Pacific \(Tokyo\), US West \(Oregon\), US West \(N\.
+    California\), Asia Pacific \(Singapore\), Asia Pacific \(Sydney\) Region
+  Description: Checks if there are any Amazon Relational Database Service \(RDS\)
+    DB security groups that are not the default DB security group\. The rule is NON\_COMPLIANT
+    is there are any DB security groups that are not the default DB security group\.
+  File: rds-db-security-group-not-allowed.md
+  FullDocumentation: "# rds\\-db\\-security\\-group\\-not\\-allowed<a name=\"rds-db-security-group-not-allowed\"\
+    ></a>\n\nChecks if there are any Amazon Relational Database Service \\(RDS\\)\
+    \ DB security groups that are not the default DB security group\\. The rule is\
+    \ NON\\_COMPLIANT is there are any DB security groups that are not the default\
+    \ DB security group\\. \n\n**Identifier:** RDS\\_DB\\_SECURITY\\_GROUP\\_NOT\\\
+    _ALLOWED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** Only available\
+    \ in Europe \\(Ireland\\), South America \\(Sao Paulo\\), US East \\(N\\. Virginia\\\
+    ), Asia Pacific \\(Tokyo\\), US West \\(Oregon\\), US West \\(N\\. California\\\
+    ), Asia Pacific \\(Singapore\\), Asia Pacific \\(Sydney\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d375c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_DB_SECURITY_GROUP_NOT_ALLOWED
+  Name: rds-db-security-group-not-allowed
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks whether enhanced monitoring is enabled for Amazon Relational
+    Database Service \(Amazon RDS\) instances\.
+  File: rds-enhanced-monitoring-enabled.md
+  FullDocumentation: "# rds\\-enhanced\\-monitoring\\-enabled<a name=\"rds-enhanced-monitoring-enabled\"\
+    ></a>\n\nChecks whether enhanced monitoring is enabled for Amazon Relational Database\
+    \ Service \\(Amazon RDS\\) instances\\. \n\n**Identifier:** RDS\\_ENHANCED\\_MONITORING\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nmonitoringInterval \\(Optional\\)Type: int  \nAn integer\
+    \ value in seconds between points when enhanced monitoring metrics are collected\
+    \ for the database instance\\. The valid values are 1, 5, 10, 15, 30, and 60\\\
+    .\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d377c15\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_ENHANCED_MONITORING_ENABLED
+  Name: rds-enhanced-monitoring-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except AWS GovCloud \(US\-East\), AWS GovCloud
+    \(US\-West\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks whether Amazon RDS database is present in back plans of AWS
+    Backup\. The rule is NON\_COMPLIANT if Amazon RDS databases are not included in
+    any AWS Backup plan\.
+  File: rds-in-backup-plan.md
+  FullDocumentation: "# rds\\-in\\-backup\\-plan<a name=\"rds-in-backup-plan\"></a>\n\
+    \nChecks whether Amazon RDS database is present in back plans of AWS Backup\\\
+    . The rule is NON\\_COMPLIANT if Amazon RDS databases are not included in any\
+    \ AWS Backup plan\\. \n\n**Identifier:** RDS\\_IN\\_BACKUP\\_PLAN\n\n**Trigger\
+    \ type:** Periodic\n\n**AWS Region:** All supported AWS regions except AWS GovCloud\
+    \ \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d387c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_IN_BACKUP_PLAN
+  Name: rds-in-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks if an Amazon Relational Database Service \(Amazon RDS\) database
+    has changed the admin username from its default value\. This rule will only run
+    on RDS database instances\. The rule is NON\_COMPLIANT if the admin username is
+    set to the default value\.
+  File: rds-instance-default-admin-check.md
+  FullDocumentation: "# rds\\-instance\\-default\\-admin\\-check<a name=\"rds-instance-default-admin-check\"\
+    ></a>\n\nChecks if an Amazon Relational Database Service \\(Amazon RDS\\) database\
+    \ has changed the admin username from its default value\\. This rule will only\
+    \ run on RDS database instances\\. The rule is NON\\_COMPLIANT if the admin username\
+    \ is set to the default value\\. \n\n**Identifier:** RDS\\_INSTANCE\\_DEFAULT\\\
+    _ADMIN\\_CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All\
+    \ supported AWS regions\n\n**Parameters:**\n\nvalidAdminUserNames \\(Optional\\\
+    )Type: CSV  \nComma\\-separated list of admin username\\(s\\) that Amazon RDS\
+    \ instances can use\\. \\(Cannot include 'postgres' or 'admin' as valid username\\\
+    (s\\) as these are default values\\.\\)\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d379c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: RDS_INSTANCE_DEFAULT_ADMIN_CHECK
+  Name: rds-instance-default-admin-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: "Checks if an Amazon Relational Database Service \\(Amazon RDS\\) instance\
+    \ has deletion protection enabled\\. This rule is NON\\_COMPLIANT if an Amazon\
+    \ RDS instance does not have deletion protection enabled i\\.e `deletionProtection`\
+    \ is set to false\\. \n\n**Warning**  \nSome RDS DB instances within a Cluster\
+    \ \\(Aurora/DocumentDB\\) will show as non\\-compliant\\."
+  File: rds-instance-deletion-protection-enabled.md
+  FullDocumentation: "# rds\\-instance\\-deletion\\-protection\\-enabled<a name=\"\
+    rds-instance-deletion-protection-enabled\"></a>\n\nChecks if an Amazon Relational\
+    \ Database Service \\(Amazon RDS\\) instance has deletion protection enabled\\\
+    . This rule is NON\\_COMPLIANT if an Amazon RDS instance does not have deletion\
+    \ protection enabled i\\.e `deletionProtection` is set to false\\. \n\n**Warning**\
+    \  \nSome RDS DB instances within a Cluster \\(Aurora/DocumentDB\\) will show\
+    \ as non\\-compliant\\.\n\n**Identifier:** RDS\\_INSTANCE\\_DELETION\\_PROTECTION\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\ndatabaseEngines \\(Optional\\)Type: CSV  \nComma\\-separated\
+    \ list of RDS database engines to include in the evaluation of the rule\\. For\
+    \ example, 'mysql, postgres, mariadb'\\.\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d381c17\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: RDS_INSTANCE_DELETION_PROTECTION_ENABLED
+  Name: rds-instance-deletion-protection-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    Asia Pacific \(Hong Kong\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\),
+    Africa \(Cape Town\) Region
+  Description: Checks if an Amazon Relational Database Service \(Amazon RDS\) instance
+    has AWS Identity and Access Management \(IAM\) authentication enabled\. This rule
+    is NON\_COMPLIANT if an Amazon RDS instance does not have AWS IAM authentication
+    enabled i\.e `configuration.iAMDatabaseAuthenticationEnabled` is set to false\.
+  File: rds-instance-iam-authentication-enabled.md
+  FullDocumentation: "# rds\\-instance\\-iam\\-authentication\\-enabled<a name=\"\
+    rds-instance-iam-authentication-enabled\"></a>\n\nChecks if an Amazon Relational\
+    \ Database Service \\(Amazon RDS\\) instance has AWS Identity and Access Management\
+    \ \\(IAM\\) authentication enabled\\. This rule is NON\\_COMPLIANT if an Amazon\
+    \ RDS instance does not have AWS IAM authentication enabled i\\.e `configuration.iAMDatabaseAuthenticationEnabled`\
+    \ is set to false\\.\n\n**Identifier:** RDS\\_INSTANCE\\_IAM\\_AUTHENTICATION\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except China \\(Beijing\\), China \\(Ningxia\\), Asia Pacific \\\
+    (Hong Kong\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Africa \\\
+    (Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d383c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_INSTANCE_IAM_AUTHENTICATION_ENABLED
+  Name: rds-instance-iam-authentication-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Check whether the Amazon Relational Database Service instances are
+    not publicly accessible\. The rule is NON\_COMPLIANT if the `publiclyAccessible`
+    field is true in the instance configuration item\.
+  File: rds-instance-public-access-check.md
+  FullDocumentation: "# rds\\-instance\\-public\\-access\\-check<a name=\"rds-instance-public-access-check\"\
+    ></a>\n\nCheck whether the Amazon Relational Database Service instances are not\
+    \ publicly accessible\\. The rule is NON\\_COMPLIANT if the `publiclyAccessible`\
+    \ field is true in the instance configuration item\\.\n\n**Identifier:** RDS\\\
+    _INSTANCE\\_PUBLIC\\_ACCESS\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7d385c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_INSTANCE_PUBLIC_ACCESS_CHECK
+  Name: rds-instance-public-access-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Ningxia\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if log types exported to Amazon CloudWatch for an Amazon Relational
+    Database Service \(Amazon RDS\) instance are enabled\. The rule is NON\_COMPLIANT
+    if any such log types are not enabled\.
+  File: rds-logging-enabled.md
+  FullDocumentation: "# rds\\-logging\\-enabled<a name=\"rds-logging-enabled\"></a>\n\
+    \nChecks if log types exported to Amazon CloudWatch for an Amazon Relational Database\
+    \ Service \\(Amazon RDS\\) instance are enabled\\. The rule is NON\\_COMPLIANT\
+    \ if any such log types are not enabled\\.\n\n**Identifier:** RDS\\_LOGGING\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except China \\(Ningxia\\), Asia Pacific \\(Jakarta\\), Asia Pacific\
+    \ \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nadditionalLogs \\(Optional\\)Type: StringMap  \nComma\\-separated list of engine\
+    \ names and log type names\\. For example, \"additionalLogs\": \"oracle: general,\
+    \ slowquery ; aurora: alert, slowquery\"\n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d389c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: RDS_LOGGING_ENABLED
+  Name: rds-logging-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: "Checks whether high availability is enabled for your RDS DB instances\\\
+    .\n\nIn a Multi\\-AZ deployment, Amazon RDS automatically provisions and maintains\
+    \ a synchronous standby replica in a different Availability Zone\\. For more information,\
+    \ see [High Availability \\(Multi\\-AZ\\)](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html)\
+    \ in the *Amazon RDS User Guide*\\.\n\n**Note**  \nThis rule does not evaluate\
+    \ Amazon Aurora DB and Amazon DocumentDB instances\\."
+  File: rds-multi-az-support.md
+  FullDocumentation: "# rds\\-multi\\-az\\-support<a name=\"rds-multi-az-support\"\
+    ></a>\n\nChecks whether high availability is enabled for your RDS DB instances\\\
+    .\n\nIn a Multi\\-AZ deployment, Amazon RDS automatically provisions and maintains\
+    \ a synchronous standby replica in a different Availability Zone\\. For more information,\
+    \ see [High Availability \\(Multi\\-AZ\\)](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html)\
+    \ in the *Amazon RDS User Guide*\\.\n\n**Note**  \nThis rule does not evaluate\
+    \ Amazon Aurora DB and Amazon DocumentDB instances\\.\n\n**Identifier:** RDS\\\
+    _MULTI\\_AZ\\_SUPPORT\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d391c19\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_MULTI_AZ_SUPPORT
+  Name: rds-multi-az-support
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if Amazon Relational Database Service \(Amazon RDS\) instances
+    are protected by a backup plan\. The rule is NON\_COMPLIANT if the Amazon RDS
+    Database instance is not covered by a backup plan\.
+  File: rds-resources-protected-by-backup-plan.md
+  FullDocumentation: "# rds\\-resources\\-protected\\-by\\-backup\\-plan<a name=\"\
+    rds-resources-protected-by-backup-plan\"></a>\n\nChecks if Amazon Relational Database\
+    \ Service \\(Amazon RDS\\) instances are protected by a backup plan\\. The rule\
+    \ is NON\\_COMPLIANT if the Amazon RDS Database instance is not covered by a backup\
+    \ plan\\. \n\n**Identifier:** RDS\\_RESOURCES\\_PROTECTED\\_BY\\_BACKUP\\_PLAN\n\
+    \n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions except\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nresourceTags \\(Optional\\)Type: String  \nTags for Amazon\
+    \ RDS instances for the rule to check, in JSON format\\.\n\nresourceId \\(Optional\\\
+    )Type: String  \nID of Amazon RDS instance for the rule to check\\.\n\ncrossRegionList\
+    \ \\(Optional\\)Type: String  \nComma\\-separated list of destination regions\
+    \ for the cross\\-region backup copy to be kept\n\ncrossAccountList \\(Optional\\\
+    )Type: String  \nComma\\-separated list of destination accounts for cross\\-account\
+    \ backup copy to be kept\n\nmaxRetentionDays \\(Optional\\)Type: int  \nThe maximum\
+    \ retention period in days for the Backup Vault Lock\n\nminRetentionDays \\(Optional\\\
+    )Type: int  \nThe minimum retention period in days for the Backup Vault Lock\n\
+    \nbackupVaultLockCheck \\(Optional\\)Type: String  \nAccepted values: 'True' or\
+    \ 'False'\\. Enter 'True' for the rule to check if the resource is backed up in\
+    \ a locked vault\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d393c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_RESOURCES_PROTECTED_BY_BACKUP_PLAN
+  Name: rds-resources-protected-by-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\) Region
+  Description: Checks whether Amazon Relational Database Service \(Amazon RDS\) DB
+    snapshots are encrypted\. The rule is NON\_COMPLIANT, if the Amazon RDS DB snapshots
+    are not encrypted\.
+  File: rds-snapshot-encrypted.md
+  FullDocumentation: "# rds\\-snapshot\\-encrypted<a name=\"rds-snapshot-encrypted\"\
+    ></a>\n\nChecks whether Amazon Relational Database Service \\(Amazon RDS\\) DB\
+    \ snapshots are encrypted\\. The rule is NON\\_COMPLIANT, if the Amazon RDS DB\
+    \ snapshots are not encrypted\\. \n\n**Identifier:** RDS\\_SNAPSHOT\\_ENCRYPTED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d397c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_SNAPSHOT_ENCRYPTED
+  Name: rds-snapshot-encrypted
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: "Checks if Amazon Relational Database Service \\(Amazon RDS\\) snapshots\
+    \ are public\\. The rule is NON\\_COMPLIANT if any existing and new Amazon RDS\
+    \ snapshots are public\\. \n\n**Note**  \nIt can take up to 12 hours for compliance\
+    \ results to be captured\\."
+  File: rds-snapshots-public-prohibited.md
+  FullDocumentation: "# rds\\-snapshots\\-public\\-prohibited<a name=\"rds-snapshots-public-prohibited\"\
+    ></a>\n\nChecks if Amazon Relational Database Service \\(Amazon RDS\\) snapshots\
+    \ are public\\. The rule is NON\\_COMPLIANT if any existing and new Amazon RDS\
+    \ snapshots are public\\. \n\n**Note**  \nIt can take up to 12 hours for compliance\
+    \ results to be captured\\.\n\n**Identifier:** RDS\\_SNAPSHOTS\\_PUBLIC\\_PROHIBITED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n\
+    ## AWS CloudFormation template<a name=\"w76aac11c31c17b7d395c17\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_SNAPSHOTS_PUBLIC_PROHIBITED
+  Name: rds-snapshots-public-prohibited
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks whether storage encryption is enabled for your RDS DB instances\.
+  File: rds-storage-encrypted.md
+  FullDocumentation: "# rds\\-storage\\-encrypted<a name=\"rds-storage-encrypted\"\
+    ></a>\n\nChecks whether storage encryption is enabled for your RDS DB instances\\\
+    . \n\n**Identifier:** RDS\\_STORAGE\\_ENCRYPTED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    kmsKeyId \\(Optional\\)Type: String  \n KMS key ID or ARN used to encrypt the\
+    \ storage\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d399c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RDS_STORAGE_ENCRYPTED
+  Name: rds-storage-encrypted
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Ningxia\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks that Amazon Redshift automated snapshots are enabled for clusters\.
+    The rule is NON\_COMPLIANT if the value for `automatedSnapshotRetentionPeriod`
+    is greater than `MaxRetentionPeriod` or less than `MinRetentionPeriod` or the
+    value is 0\.
+  File: redshift-backup-enabled.md
+  FullDocumentation: "# redshift\\-backup\\-enabled<a name=\"redshift-backup-enabled\"\
+    ></a>\n\nChecks that Amazon Redshift automated snapshots are enabled for clusters\\\
+    . The rule is NON\\_COMPLIANT if the value for `automatedSnapshotRetentionPeriod`\
+    \ is greater than `MaxRetentionPeriod` or less than `MinRetentionPeriod` or the\
+    \ value is 0\\.\n\n**Identifier:** REDSHIFT\\_BACKUP\\_ENABLED\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except China\
+    \ \\(Ningxia\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nMinRetentionPeriod\
+    \ \\(Optional\\)Type: int  \nMinimum value for the retention period\\. Minimum\
+    \ value is 1\\.\n\nMaxRetentionPeriod \\(Optional\\)Type: int  \nMaximum value\
+    \ for the retention period\\. Maximum value is 35\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d401c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REDSHIFT_BACKUP_ENABLED
+  Name: redshift-backup-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Middle East \(Bahrain\) Region
+  Description: Checks whether Amazon Redshift clusters have the specified settings\.
+  File: redshift-cluster-configuration-check.md
+  FullDocumentation: "# redshift\\-cluster\\-configuration\\-check<a name=\"redshift-cluster-configuration-check\"\
+    ></a>\n\nChecks whether Amazon Redshift clusters have the specified settings\\\
+    . \n\n**Identifier:** REDSHIFT\\_CLUSTER\\_CONFIGURATION\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ Middle East \\(Bahrain\\) Region\n\n**Parameters:**\n\nclusterDbEncryptedType:\
+    \ booleanDefault: true  \nDatabase encryption is enabled\\.\n\nloggingEnabledType:\
+    \ booleanDefault: true  \nAudit logging is enabled\\.\n\nnodeTypes \\(Optional\\\
+    )Type: CSVDefault: dc1\\.large  \nSpecify node type\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d403c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REDSHIFT_CLUSTER_CONFIGURATION_CHECK
+  Name: redshift-cluster-configuration-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if Amazon Redshift clusters are using a specified AWS Key Management
+    Service \(AWS KMS\) key for encryption\. The rule is COMPLIANT if encryption is
+    enabled and the cluster is encrypted with the key provided in the `kmsKeyArn`
+    parameter\. The rule is NON\_COMPLIANT if the cluster is not encrypted or encrypted
+    with another key\.
+  File: redshift-cluster-kms-enabled.md
+  FullDocumentation: "# redshift\\-cluster\\-kms\\-enabled<a name=\"redshift-cluster-kms-enabled\"\
+    ></a>\n\nChecks if Amazon Redshift clusters are using a specified AWS Key Management\
+    \ Service \\(AWS KMS\\) key for encryption\\. The rule is COMPLIANT if encryption\
+    \ is enabled and the cluster is encrypted with the key provided in the `kmsKeyArn`\
+    \ parameter\\. The rule is NON\\_COMPLIANT if the cluster is not encrypted or\
+    \ encrypted with another key\\.\n\n**Identifier:** REDSHIFT\\_CLUSTER\\_KMS\\\
+    _ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\\
+    (US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nkmsKeyArns \\(Optional\\)Type:\
+    \ CSV  \nComma\\-separated list of AWS KMS key Amazon Resource Names \\(ARNs\\\
+    ) used in Amazon Redshift clusters for encryption\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d405c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REDSHIFT_CLUSTER_KMS_ENABLED
+  Name: redshift-cluster-kms-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Middle East \(Bahrain\) Region
+  Description: Checks whether Amazon Redshift clusters have the specified maintenance
+    settings\.
+  File: redshift-cluster-maintenancesettings-check.md
+  FullDocumentation: "# redshift\\-cluster\\-maintenancesettings\\-check<a name=\"\
+    redshift-cluster-maintenancesettings-check\"></a>\n\nChecks whether Amazon Redshift\
+    \ clusters have the specified maintenance settings\\. \n\n**Identifier:** REDSHIFT\\\
+    _CLUSTER\\_MAINTENANCESETTINGS\\_CHECK\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except Middle East \\(Bahrain\\) Region\n\
+    \n**Parameters:**\n\nallowVersionUpgradeType: booleanDefault: true  \nAllow version\
+    \ upgrade is enabled\\.\n\npreferredMaintenanceWindow \\(Optional\\)Type: String\
+    \  \nScheduled maintenance window for clusters \\(for example, Mon:09:30\\-Mon:10:00\\\
+    )\\.\n\nautomatedSnapshotRetentionPeriod \\(Optional\\)Type: intDefault: 1  \n\
+    Number of days to retain automated snapshots\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d407c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REDSHIFT_CLUSTER_MAINTENANCESETTINGS_CHECK
+  Name: redshift-cluster-maintenancesettings-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks if Amazon Redshift clusters are not publicly accessible\. The
+    rule is NON\_COMPLIANT if the `publiclyAccessible` field is true in the cluster
+    configuration item\.
+  File: redshift-cluster-public-access-check.md
+  FullDocumentation: "# redshift\\-cluster\\-public\\-access\\-check<a name=\"redshift-cluster-public-access-check\"\
+    ></a>\n\nChecks if Amazon Redshift clusters are not publicly accessible\\. The\
+    \ rule is NON\\_COMPLIANT if the `publiclyAccessible` field is true in the cluster\
+    \ configuration item\\.\n\n**Identifier:** REDSHIFT\\_CLUSTER\\_PUBLIC\\_ACCESS\\\
+    _CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d409c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REDSHIFT_CLUSTER_PUBLIC_ACCESS_CHECK
+  Name: redshift-cluster-public-access-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: "Checks if an Amazon Redshift cluster has changed the admin username\
+    \ from its default value\\. The rule is NON\\_COMPLIANT if the admin username\
+    \ for a Redshift cluster is set to \u201Cawsuser\u201D or if the username does\
+    \ not match what is listed in parameter\\."
+  File: redshift-default-admin-check.md
+  FullDocumentation: "# redshift\\-default\\-admin\\-check<a name=\"redshift-default-admin-check\"\
+    ></a>\n\nChecks if an Amazon Redshift cluster has changed the admin username from\
+    \ its default value\\. The rule is NON\\_COMPLIANT if the admin username for a\
+    \ Redshift cluster is set to \u201Cawsuser\u201D or if the username does not match\
+    \ what is listed in parameter\\. \n\n**Identifier:** REDSHIFT\\_DEFAULT\\_ADMIN\\\
+    _CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions\n\n**Parameters:**\n\nvalidAdminUserNames \\(Optional\\)Type: CSV\
+    \  \nComma\\-separated list of admin username\\(s\\) for Redshift clusters to\
+    \ use\\. Note: 'awsuser' is the default and not accepted\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d411c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REDSHIFT_DEFAULT_ADMIN_CHECK
+  Name: redshift-default-admin-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: "Checks if a Redshift cluster has changed its database name from the\
+    \ default value\\. The rule is NON\\_COMPLIANT if the database name for a Redshift\
+    \ cluster is set to \u201Cdev\u201D, or if the optional parameter is provided\
+    \ and the database name does not match\\."
+  File: redshift-default-db-name-check.md
+  FullDocumentation: "# redshift\\-default\\-db\\-name\\-check<a name=\"redshift-default-db-name-check\"\
+    ></a>\n\nChecks if a Redshift cluster has changed its database name from the default\
+    \ value\\. The rule is NON\\_COMPLIANT if the database name for a Redshift cluster\
+    \ is set to \u201Cdev\u201D, or if the optional parameter is provided and the\
+    \ database name does not match\\. \n\n**Identifier:** REDSHIFT\\_DEFAULT\\_DB\\\
+    _NAME\\_CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All\
+    \ supported AWS regions\n\n**Parameters:**\n\nvalidDatabaseNames \\(Optional\\\
+    )Type: CSV  \nComma\\-separated list of database name\\(s\\) for Redshift clusters\\\
+    .\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d413c15\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REDSHIFT_DEFAULT_DB_NAME_CHECK
+  Name: redshift-default-db-name-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if Amazon Redshift cluster has 'enhancedVpcRouting' enabled\.
+    The rule is NON\_COMPLIANT if 'enhancedVpcRouting' is not enabled or if the configuration\.enhancedVpcRouting
+    field is 'false'\.
+  File: redshift-enhanced-vpc-routing-enabled.md
+  FullDocumentation: "# redshift\\-enhanced\\-vpc\\-routing\\-enabled<a name=\"redshift-enhanced-vpc-routing-enabled\"\
+    ></a>\n\nChecks if Amazon Redshift cluster has 'enhancedVpcRouting' enabled\\\
+    . The rule is NON\\_COMPLIANT if 'enhancedVpcRouting' is not enabled or if the\
+    \ configuration\\.enhancedVpcRouting field is 'false'\\. \n\n**Identifier:** REDSHIFT\\\
+    _ENHANCED\\_VPC\\_ROUTING\\_ENABLED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except China \\(Beijing\\), China\
+    \ \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\n\
+    None  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d415c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REDSHIFT_ENHANCED_VPC_ROUTING_ENABLED
+  Name: redshift-enhanced-vpc-routing-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\) Region
+  Description: Checks whether Amazon Redshift clusters require TLS/SSL encryption
+    to connect to SQL clients\. The rule is NON\_COMPLIANT if any Amazon Redshift
+    cluster has parameter require\_SSL not set to true\.
+  File: redshift-require-tls-ssl.md
+  FullDocumentation: "# redshift\\-require\\-tls\\-ssl<a name=\"redshift-require-tls-ssl\"\
+    ></a>\n\nChecks whether Amazon Redshift clusters require TLS/SSL encryption to\
+    \ connect to SQL clients\\. The rule is NON\\_COMPLIANT if any Amazon Redshift\
+    \ cluster has parameter require\\_SSL not set to true\\. \n\n**Identifier:** REDSHIFT\\\
+    _REQUIRE\\_TLS\\_SSL\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\\
+    (Osaka\\), Europe \\(Milan\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d417c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REDSHIFT_REQUIRE_TLS_SSL
+  Name: redshift-require-tls-ssl
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: "Checks if your resources have the tags that you specify\\. For example,\
+    \ you can check whether your Amazon EC2 instances have the `CostCenter` tag\\\
+    . Separate multiple values with commas\\. You can check up to 6 tags at a time\\\
+    .\n\nThe AWS\\-managed AWS Systems Manager automation document `AWS-SetRequiredTags`\
+    \ does not work as a remediation with this rule\\. You will need to create your\
+    \ own custom Systems Manager automation documentation for remediation\\.\n\n**Important**\
+    \  \nThe supported resource types for this rule are as follows:  \nACM::Certificate\n\
+    AutoScaling::AutoScalingGroup\nCloudFormation::Stack\nCodeBuild::Project\nDynamoDB::Table\n\
+    EC2::CustomerGateway\nEC2::Instance\nEC2::InternetGateway\nEC2::NetworkAcl\nEC2::NetworkInterface\n\
+    EC2::RouteTable\nEC2::SecurityGroup\nEC2::Subnet\nEC2::Volume\nEC2::VPC\nEC2::VPNConnection\n\
+    EC2::VPNGateway\nElasticLoadBalancing::LoadBalancer\nElasticLoadBalancingV2::LoadBalancer\n\
+    RDS::DBInstance\nRDS::DBSecurityGroup\nRDS::DBSnapshot\nRDS::DBSubnetGroup\nRDS::EventSubscription\n\
+    Redshift::Cluster\nRedshift::ClusterParameterGroup\nRedshift::ClusterSecurityGroup\n\
+    Redshift::ClusterSnapshot\nRedshift::ClusterSubnetGroup\nS3::Bucket"
+  File: required-tags.md
+  FullDocumentation: "# required\\-tags<a name=\"required-tags\"></a>\n\nChecks if\
+    \ your resources have the tags that you specify\\. For example, you can check\
+    \ whether your Amazon EC2 instances have the `CostCenter` tag\\. Separate multiple\
+    \ values with commas\\. You can check up to 6 tags at a time\\.\n\nThe AWS\\-managed\
+    \ AWS Systems Manager automation document `AWS-SetRequiredTags` does not work\
+    \ as a remediation with this rule\\. You will need to create your own custom Systems\
+    \ Manager automation documentation for remediation\\.\n\n**Important**  \nThe\
+    \ supported resource types for this rule are as follows:  \nACM::Certificate\n\
+    AutoScaling::AutoScalingGroup\nCloudFormation::Stack\nCodeBuild::Project\nDynamoDB::Table\n\
+    EC2::CustomerGateway\nEC2::Instance\nEC2::InternetGateway\nEC2::NetworkAcl\nEC2::NetworkInterface\n\
+    EC2::RouteTable\nEC2::SecurityGroup\nEC2::Subnet\nEC2::Volume\nEC2::VPC\nEC2::VPNConnection\n\
+    EC2::VPNGateway\nElasticLoadBalancing::LoadBalancer\nElasticLoadBalancingV2::LoadBalancer\n\
+    RDS::DBInstance\nRDS::DBSecurityGroup\nRDS::DBSnapshot\nRDS::DBSubnetGroup\nRDS::EventSubscription\n\
+    Redshift::Cluster\nRedshift::ClusterParameterGroup\nRedshift::ClusterSecurityGroup\n\
+    Redshift::ClusterSnapshot\nRedshift::ClusterSubnetGroup\nS3::Bucket\n\n**Identifier:**\
+    \ REQUIRED\\_TAGS\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions\n\n**Parameters:**\n\ntag1KeyType: StringDefault:\
+    \ CostCenter  \nKey of the required tag\\.\n\ntag1Value \\(Optional\\)Type: CSV\
+    \  \nOptional value of the required tag\\. Separate multiple values with commas\\\
+    .\n\ntag2Key \\(Optional\\)Type: String  \nKey of a second required tag\\.\n\n\
+    tag2Value \\(Optional\\)Type: CSV  \nOptional value of the second required tag\\\
+    . Separate multiple values with commas\\.\n\ntag3Key \\(Optional\\)Type: String\
+    \  \nKey of a third required tag\\.\n\ntag3Value \\(Optional\\)Type: CSV  \nOptional\
+    \ value of the third required tag\\. Separate multiple values with commas\\.\n\
+    \ntag4Key \\(Optional\\)Type: String  \nKey of a fourth required tag\\.\n\ntag4Value\
+    \ \\(Optional\\)Type: CSV  \nOptional value of the fourth required tag\\. Separate\
+    \ multiple values with commas\\.\n\ntag5Key \\(Optional\\)Type: String  \nKey\
+    \ of a fifth required tag\\.\n\ntag5Value \\(Optional\\)Type: CSV  \nOptional\
+    \ value of the fifth required tag\\. Separate multiple values with commas\\.\n\
+    \ntag6Key \\(Optional\\)Type: String  \nKey of a sixth required tag\\.\n\ntag6Value\
+    \ \\(Optional\\)Type: CSV  \nOptional value of the sixth required tag\\. Separate\
+    \ multiple values with commas\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d419c19\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: REQUIRED_TAGS
+  Name: required-tags
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if the security groups in use do not allow unrestricted incoming
+    TCP traffic to the specified ports\. The rule is COMPLIANT when the IP addresses
+    for inbound TCP connections are restricted to the specified ports\. This rule
+    applies only to IPv4\.
+  File: restricted-common-ports.md
+  FullDocumentation: "# restricted\\-common\\-ports<a name=\"restricted-common-ports\"\
+    ></a>\n\nChecks if the security groups in use do not allow unrestricted incoming\
+    \ TCP traffic to the specified ports\\. The rule is COMPLIANT when the IP addresses\
+    \ for inbound TCP connections are restricted to the specified ports\\. This rule\
+    \ applies only to IPv4\\. \n\n**Identifier:** RESTRICTED\\_INCOMING\\_TRAFFIC\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe\
+    \ \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nblockedPort1\
+    \ \\(Optional\\)Type: intDefault: 20  \nBlocked TCP port number\\.\n\nblockedPort2\
+    \ \\(Optional\\)Type: intDefault: 21  \nBlocked TCP port number\\.\n\nblockedPort3\
+    \ \\(Optional\\)Type: intDefault: 3389  \nBlocked TCP port number\\.\n\nblockedPort4\
+    \ \\(Optional\\)Type: intDefault: 3306  \nBlocked TCP port number\\.\n\nblockedPort5\
+    \ \\(Optional\\)Type: intDefault: 4333  \nBlocked TCP port number\\.\n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d421c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: RESTRICTED_INCOMING_TRAFFIC
+  Name: restricted-common-ports
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks if the incoming SSH traffic for the security groups is accessible\.
+    The rule is COMPLIANT when IP addresses of the incoming SSH traffic in the security
+    groups are restricted \(CIDR other than 0\.0\.0\.0/0\)\. This rule applies only
+    to IPv4\.
+  File: restricted-ssh.md
+  FullDocumentation: "# restricted\\-ssh<a name=\"restricted-ssh\"></a>\n\nChecks\
+    \ if the incoming SSH traffic for the security groups is accessible\\. The rule\
+    \ is COMPLIANT when IP addresses of the incoming SSH traffic in the security groups\
+    \ are restricted \\(CIDR other than 0\\.0\\.0\\.0/0\\)\\. This rule applies only\
+    \ to IPv4\\.\n\n**Identifier:** INCOMING\\_SSH\\_DISABLED\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa\
+    \ \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d317c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: INCOMING_SSH_DISABLED
+  Name: restricted-ssh
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\) Region
+  Description: Checks if your AWS account is enabled to use multi\-factor authentication
+    \(MFA\) hardware device to sign in with root credentials\. The rule is NON\_COMPLIANT
+    if any virtual MFA devices are permitted for signing in with root credentials\.
+  File: root-account-hardware-mfa-enabled.md
+  FullDocumentation: "# root\\-account\\-hardware\\-mfa\\-enabled<a name=\"root-account-hardware-mfa-enabled\"\
+    ></a>\n\nChecks if your AWS account is enabled to use multi\\-factor authentication\
+    \ \\(MFA\\) hardware device to sign in with root credentials\\. The rule is NON\\\
+    _COMPLIANT if any virtual MFA devices are permitted for signing in with root credentials\\\
+    .\n\n**Identifier:** ROOT\\_ACCOUNT\\_HARDWARE\\_MFA\\_ENABLED\n\n**Trigger type:**\
+    \ Periodic\n\n**AWS Region:** All supported AWS regions except China \\(Beijing\\\
+    ), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\\
+    ) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d423c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: ROOT_ACCOUNT_HARDWARE_MFA_ENABLED
+  Name: root-account-hardware-mfa-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\) Region
+  Description: Checks whether the root user of your AWS account requires multi\-factor
+    authentication for console sign\-in\.
+  File: root-account-mfa-enabled.md
+  FullDocumentation: "# root\\-account\\-mfa\\-enabled<a name=\"root-account-mfa-enabled\"\
+    ></a>\n\nChecks whether the root user of your AWS account requires multi\\-factor\
+    \ authentication for console sign\\-in\\. \n\n**Identifier:** ROOT\\_ACCOUNT\\\
+    _MFA\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported\
+    \ AWS regions except China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\\
+    (US\\-East\\), AWS GovCloud \\(US\\-West\\) Region\n\n**Parameters:**\n\nNone\
+    \  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d425c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: ROOT_ACCOUNT_MFA_ENABLED
+  Name: root-account-mfa-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\) Region
+  Description: Checks if the required public access block settings are configured
+    from account level\.
+  File: s3-account-level-public-access-blocks-periodic.md
+  FullDocumentation: "# s3\\-account\\-level\\-public\\-access\\-blocks\\-periodic<a\
+    \ name=\"s3-account-level-public-access-blocks-periodic\"></a>\n\nChecks if the\
+    \ required public access block settings are configured from account level\\. \n\
+    \n**Identifier:** S3\\_ACCOUNT\\_LEVEL\\_PUBLIC\\_ACCESS\\_BLOCKS\\_PERIODIC\n\
+    \n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS\
+    \ GovCloud \\(US\\-West\\) Region\n\n**Parameters:**\n\nIgnorePublicAcls \\(Optional\\\
+    )Type: String  \nIgnorePublicAcls is enforced or not, default True\n\nBlockPublicPolicy\
+    \ \\(Optional\\)Type: String  \nBlockPublicPolicy is enforced or not, default\
+    \ True\n\nBlockPublicAcls \\(Optional\\)Type: String  \nBlockPublicAcls is enforced\
+    \ or not, default True\n\nRestrictPublicBuckets \\(Optional\\)Type: String  \n\
+    RestrictPublicBuckets is enforced or not, default True\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d429c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_ACCOUNT_LEVEL_PUBLIC_ACCESS_BLOCKS_PERIODIC
+  Name: s3-account-level-public-access-blocks-periodic
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\), Europe \(Milan\), Middle East \(Bahrain\) Region
+  Description: "Checks if the required public access block settings are configured\
+    \ from account level\\. The rule is only NON\\_COMPLIANT when the fields set below\
+    \ do not match the corresponding fields in the configuration item\\.\n\n**Note**\
+    \  \nIf you are using this rule, ensure that S3 Block Public Access is enabled\\\
+    . The rule is change\\-triggered, so it will not be invoked unless S3 Block Public\
+    \ Access is enabled\\. If S3 Block Public Access is not enabled the rule returns\
+    \ INSUFFICIENT\\_DATA\\. This means that you still might have some public buckets\\\
+    . For more information about setting up S3 Block Public Access, see [Blocking\
+    \ public access to your Amazon S3 storage](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html)\\\
+    ."
+  File: s3-account-level-public-access-blocks.md
+  FullDocumentation: "# s3\\-account\\-level\\-public\\-access\\-blocks<a name=\"\
+    s3-account-level-public-access-blocks\"></a>\n\nChecks if the required public\
+    \ access block settings are configured from account level\\. The rule is only\
+    \ NON\\_COMPLIANT when the fields set below do not match the corresponding fields\
+    \ in the configuration item\\.\n\n**Note**  \nIf you are using this rule, ensure\
+    \ that S3 Block Public Access is enabled\\. The rule is change\\-triggered, so\
+    \ it will not be invoked unless S3 Block Public Access is enabled\\. If S3 Block\
+    \ Public Access is not enabled the rule returns INSUFFICIENT\\_DATA\\. This means\
+    \ that you still might have some public buckets\\. For more information about\
+    \ setting up S3 Block Public Access, see [Blocking public access to your Amazon\
+    \ S3 storage](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html)\\\
+    .\n\n**Identifier:** S3\\_ACCOUNT\\_LEVEL\\_PUBLIC\\_ACCESS\\_BLOCKS\n\n**Trigger\
+    \ type:** Configuration changes \\(current status not checked, only evaluated\
+    \ when changes generate new events\\)\n\n**Note**  \nThis rule is only triggered\
+    \ by configuration changes for the specific region where the S3 endpoint is located\\\
+    . In all other regions, the rule is checked periodically\\. If a change was made\
+    \ in another region, there could be a delay before the rule returns NON\\_COMPLIANT\\\
+    . \n\n**AWS Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Middle East \\(Bahrain\\) Region\n\
+    \n**Parameters:**\n\nIgnorePublicAcls \\(Optional\\)Type: StringDefault: True\
+    \  \nIgnorePublicAcls is enforced or not, default True\n\nBlockPublicPolicy \\\
+    (Optional\\)Type: StringDefault: True  \nBlockPublicPolicy is enforced or not,\
+    \ default True\n\nBlockPublicAcls \\(Optional\\)Type: StringDefault: True  \n\
+    BlockPublicAcls is enforced or not, default True\n\nRestrictPublicBuckets \\(Optional\\\
+    )Type: StringDefault: True  \nRestrictPublicBuckets is enforced or not, default\
+    \ True\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d427c19\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_ACCOUNT_LEVEL_PUBLIC_ACCESS_BLOCKS
+  Name: s3-account-level-public-access-blocks
+  TriggerType: Configuration changes \(current status not checked, only evaluated
+    when changes generate new events\)
+- AWSRegion: All supported AWS regions
+  Description: Checks if Amazon Simple Storage Service \(Amazon S3\) Buckets allow
+    user permissions through access control lists \(ACLs\)\. The rule is NON\_COMPLIANT
+    if ACLs are configured for user access in Amazon S3 Buckets\.
+  File: s3-bucket-acl-prohibited.md
+  FullDocumentation: "# s3\\-bucket\\-acl\\-prohibited<a name=\"s3-bucket-acl-prohibited\"\
+    ></a>\n\nChecks if Amazon Simple Storage Service \\(Amazon S3\\) Buckets allow\
+    \ user permissions through access control lists \\(ACLs\\)\\. The rule is NON\\\
+    _COMPLIANT if ACLs are configured for user access in Amazon S3 Buckets\\. \n\n\
+    **Identifier:** S3\\_BUCKET\\_ACL\\_PROHIBITED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    None  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d431c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_ACL_PROHIBITED
+  Name: s3-bucket-acl-prohibited
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if the Amazon Simple Storage Service bucket policy does not
+    allow blacklisted bucket\-level and object\-level actions on resources in the
+    bucket for principals from other AWS accounts\. For example, the rule checks that
+    the Amazon S3 bucket policy does not allow another AWS account to perform any
+    s3:GetBucket\* actions and s3:DeleteObject on any object in the bucket\. The rule
+    is NON\_COMPLIANT if any blacklisted actions are allowed by the Amazon S3 bucket
+    policy\.
+  File: s3-bucket-blacklisted-actions-prohibited.md
+  FullDocumentation: "# s3\\-bucket\\-blacklisted\\-actions\\-prohibited<a name=\"\
+    s3-bucket-blacklisted-actions-prohibited\"></a>\n\nChecks if the Amazon Simple\
+    \ Storage Service bucket policy does not allow blacklisted bucket\\-level and\
+    \ object\\-level actions on resources in the bucket for principals from other\
+    \ AWS accounts\\. For example, the rule checks that the Amazon S3 bucket policy\
+    \ does not allow another AWS account to perform any s3:GetBucket\\* actions and\
+    \ s3:DeleteObject on any object in the bucket\\. The rule is NON\\_COMPLIANT if\
+    \ any blacklisted actions are allowed by the Amazon S3 bucket policy\\.\n\n**Identifier:**\
+    \ S3\\_BUCKET\\_BLACKLISTED\\_ACTIONS\\_PROHIBITED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    blacklistedActionPatternType: CSV  \nComma\\-separated list of blacklisted action\
+    \ patterns, for example, s3:GetBucket\\* and s3:DeleteObject\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d433c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_BLACKLISTED_ACTIONS_PROHIBITED
+  Name: s3-bucket-blacklisted-actions-prohibited
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks whether Amazon S3 bucket has lock enabled, by default\. The
+    rule is NON\_COMPLIANT if the lock is not enabled\.
+  File: s3-bucket-default-lock-enabled.md
+  FullDocumentation: "# s3\\-bucket\\-default\\-lock\\-enabled<a name=\"s3-bucket-default-lock-enabled\"\
+    ></a>\n\nChecks whether Amazon S3 bucket has lock enabled, by default\\. The rule\
+    \ is NON\\_COMPLIANT if the lock is not enabled\\. \n\n**Identifier:** S3\\_BUCKET\\\
+    _DEFAULT\\_LOCK\\_ENABLED\n\n**Trigger type:** Configuration changes\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nmode \\(Optional\\)Type: String\
+    \  \nmode: \\(optional\\): A mode parameter with valid values of GOVERNANCE or\
+    \ COMPLIANCE\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d435c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_DEFAULT_LOCK_ENABLED
+  Name: s3-bucket-default-lock-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if Amazon Simple Storage Service \(Amazon S3\) buckets are publicly
+    accessible\. This rule is NON\_COMPLIANT if an Amazon S3 bucket is not listed
+    in the `excludedPublicBuckets` parameter and bucket level settings are public\.
+  File: s3-bucket-level-public-access-prohibited.md
+  FullDocumentation: "# s3\\-bucket\\-level\\-public\\-access\\-prohibited<a name=\"\
+    s3-bucket-level-public-access-prohibited\"></a>\n\nChecks if Amazon Simple Storage\
+    \ Service \\(Amazon S3\\) buckets are publicly accessible\\. This rule is NON\\\
+    _COMPLIANT if an Amazon S3 bucket is not listed in the `excludedPublicBuckets`\
+    \ parameter and bucket level settings are public\\. \n\n**Identifier:** S3\\_BUCKET\\\
+    _LEVEL\\_PUBLIC\\_ACCESS\\_PROHIBITED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions except China \\(Beijing\\), China\
+    \ \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\n\
+    excludedPublicBuckets \\(Optional\\)Type: CSV  \nComma\\-separated list of known\
+    \ allowed public Amazon S3 bucket names\\.\n\n## AWS CloudFormation template<a\
+    \ name=\"w76aac11c31c17b7d437c15\"></a>\n\nTo create AWS Config managed rules\
+    \ with AWS CloudFormation templates, see [Creating AWS Config Managed Rules With\
+    \ AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_LEVEL_PUBLIC_ACCESS_PROHIBITED
+  Name: s3-bucket-level-public-access-prohibited
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks whether logging is enabled for your S3 buckets\.
+  File: s3-bucket-logging-enabled.md
+  FullDocumentation: "# s3\\-bucket\\-logging\\-enabled<a name=\"s3-bucket-logging-enabled\"\
+    ></a>\n\nChecks whether logging is enabled for your S3 buckets\\. \n\n**Identifier:**\
+    \ S3\\_BUCKET\\_LOGGING\\_ENABLED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\ntargetBucket\
+    \ \\(Optional\\)Type: String  \nTarget S3 bucket for storing server access logs\\\
+    .\n\ntargetPrefix \\(Optional\\)Type: String  \nPrefix of the S3 bucket for storing\
+    \ server access logs\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d439c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_LOGGING_ENABLED
+  Name: s3-bucket-logging-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: "Checks that the access granted by the Amazon S3 bucket is restricted\
+    \ by any of the AWS principals, federated users, service principals, IP addresses,\
+    \ or VPCs that you provide\\. The rule is COMPLIANT if a bucket policy is not\
+    \ present\\.\n\nFor example, if the input parameter to the rule is the list of\
+    \ two principals: `111122223333` and `444455556666` and the bucket policy specifies\
+    \ that only `111122223333` can access the bucket, then the rule is COMPLIANT\\\
+    . With the same input parameters: If the bucket policy specifies that `111122223333`\
+    \ and `444455556666` can access the bucket, it is also compliant\\. However, if\
+    \ the bucket policy specifies that `999900009999` can access the bucket, the rule\
+    \ is NON\\-COMPLIANT\\. \n\n**Note**  \nIf a bucket policy contains more than\
+    \ one statement, each statement in the bucket policy is evaluated against this\
+    \ rule\\."
+  File: s3-bucket-policy-grantee-check.md
+  FullDocumentation: "# s3\\-bucket\\-policy\\-grantee\\-check<a name=\"s3-bucket-policy-grantee-check\"\
+    ></a>\n\nChecks that the access granted by the Amazon S3 bucket is restricted\
+    \ by any of the AWS principals, federated users, service principals, IP addresses,\
+    \ or VPCs that you provide\\. The rule is COMPLIANT if a bucket policy is not\
+    \ present\\.\n\nFor example, if the input parameter to the rule is the list of\
+    \ two principals: `111122223333` and `444455556666` and the bucket policy specifies\
+    \ that only `111122223333` can access the bucket, then the rule is COMPLIANT\\\
+    . With the same input parameters: If the bucket policy specifies that `111122223333`\
+    \ and `444455556666` can access the bucket, it is also compliant\\. However, if\
+    \ the bucket policy specifies that `999900009999` can access the bucket, the rule\
+    \ is NON\\-COMPLIANT\\. \n\n**Note**  \nIf a bucket policy contains more than\
+    \ one statement, each statement in the bucket policy is evaluated against this\
+    \ rule\\.\n\n**Identifier:** S3\\_BUCKET\\_POLICY\\_GRANTEE\\_CHECK\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\nawsPrincipals \\(Optional\\)Type: CSV  \nComma\\-separated\
+    \ list of principals such as IAM User ARNs, IAM Role ARNs and AWS accounts, for\
+    \ example 'arn:aws:iam::111122223333:user/Alice, arn:aws:iam::444455556666:role/Bob,\
+    \ 123456789012'\\.\n\nservicePrincipals \\(Optional\\)Type: CSV  \nComma\\-separated\
+    \ list of service principals, for example 'cloudtrail\\.amazonaws\\.com, lambda\\\
+    .amazonaws\\.com'\\.\n\nfederatedUsers \\(Optional\\)Type: CSV  \nComma\\-separated\
+    \ list of identity providers for web identity federation such as Amazon Cognito\
+    \ and SAML identity providers\\. For example 'cognito\\-identity\\.amazonaws\\\
+    .com, arn:aws:iam::111122223333:saml\\-provider/my\\-provider'\\.\n\nipAddresses\
+    \ \\(Optional\\)Type: CSV  \nComma\\-separated list of CIDR formatted IP addresses,\
+    \ for example '10\\.0\\.0\\.1, 192\\.168\\.1\\.0/24, 2001:db8::/32'\\.\n\nvpcIds\
+    \ \\(Optional\\)Type: CSV  \nComma\\-separated list of Amazon Virtual Private\
+    \ Clouds \\(Amazon VPC\\) IDs, for example 'vpc\\-1234abc0, vpc\\-ab1234c0'\\\
+    .\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d441c19\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_POLICY_GRANTEE_CHECK
+  Name: s3-bucket-policy-grantee-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: "Checks if your Amazon Simple Storage Service bucket policies do not\
+    \ allow other inter\\-account permissions than the control Amazon S3 bucket policy\
+    \ that you provide\\.\n\n**Note**  \nIf you provide an invalid parameter value,\
+    \ you will see the following error: Value for controlPolicy parameter must be\
+    \ an Amazon S3 bucket policy\\."
+  File: s3-bucket-policy-not-more-permissive.md
+  FullDocumentation: "# s3\\-bucket\\-policy\\-not\\-more\\-permissive<a name=\"s3-bucket-policy-not-more-permissive\"\
+    ></a>\n\nChecks if your Amazon Simple Storage Service bucket policies do not allow\
+    \ other inter\\-account permissions than the control Amazon S3 bucket policy that\
+    \ you provide\\.\n\n**Note**  \nIf you provide an invalid parameter value, you\
+    \ will see the following error: Value for controlPolicy parameter must be an Amazon\
+    \ S3 bucket policy\\. \n\n**Identifier:** S3\\_BUCKET\\_POLICY\\_NOT\\_MORE\\\
+    _PERMISSIVE\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All\
+    \ supported AWS regions\n\n**Parameters:**\n\ncontrolPolicyType: String  \nAmazon\
+    \ S3 bucket policy that defines an upper bound on the permissions of your S3 buckets\\\
+    . The policy can be a maximum of 1024 characters long\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d443c17\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_POLICY_NOT_MORE_PERMISSIVE
+  Name: s3-bucket-policy-not-more-permissive
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: 'Checks if your Amazon S3 buckets do not allow public read access\.
+    The rule checks the Block Public Access settings, the bucket policy, and the bucket
+    access control list \(ACL\)\.
+
+
+    The rule is compliant when both of the following are true:
+
+    + The Block Public Access setting restricts public policies or the bucket policy
+    does not allow public read access\.
+
+    + The Block Public Access setting restricts public ACLs or the bucket ACL does
+    not allow public read access\.
+
+
+    The rule is noncompliant when:
+
+    + If the Block Public Access setting does not restrict public policies, AWS Config
+    evaluates whether the policy allows public read access\. If the policy allows
+    public read access, the rule is noncompliant\.
+
+    + If the Block Public Access setting does not restrict public bucket ACLs, AWS
+    Config evaluates whether the bucket ACL allows public read access\. If the bucket
+    ACL allows public read access, the rule is noncompliant\.'
+  File: s3-bucket-public-read-prohibited.md
+  FullDocumentation: "# s3\\-bucket\\-public\\-read\\-prohibited<a name=\"s3-bucket-public-read-prohibited\"\
+    ></a>\n\nChecks if your Amazon S3 buckets do not allow public read access\\. The\
+    \ rule checks the Block Public Access settings, the bucket policy, and the bucket\
+    \ access control list \\(ACL\\)\\.\n\nThe rule is compliant when both of the following\
+    \ are true:\n+ The Block Public Access setting restricts public policies or the\
+    \ bucket policy does not allow public read access\\.\n+ The Block Public Access\
+    \ setting restricts public ACLs or the bucket ACL does not allow public read access\\\
+    .\n\nThe rule is noncompliant when:\n+ If the Block Public Access setting does\
+    \ not restrict public policies, AWS Config evaluates whether the policy allows\
+    \ public read access\\. If the policy allows public read access, the rule is noncompliant\\\
+    .\n+ If the Block Public Access setting does not restrict public bucket ACLs,\
+    \ AWS Config evaluates whether the bucket ACL allows public read access\\. If\
+    \ the bucket ACL allows public read access, the rule is noncompliant\\.\n\n**Identifier:**\
+    \ S3\\_BUCKET\\_PUBLIC\\_READ\\_PROHIBITED\n\n**Trigger type:** Configuration\
+    \ changes and Periodic\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\
+    \nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d445c23\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_PUBLIC_READ_PROHIBITED
+  Name: s3-bucket-public-read-prohibited
+  TriggerType: Configuration changes and Periodic
+- AWSRegion: All supported AWS regions
+  Description: 'Checks if your Amazon S3 buckets do not allow public write access\.
+    The rule checks the Block Public Access settings, the bucket policy, and the bucket
+    access control list \(ACL\)\.
+
+
+    The rule is compliant when both of the following are true:
+
+    + The Block Public Access setting restricts public policies or the bucket policy
+    does not allow public write access\.
+
+    + The Block Public Access setting restricts public ACLs or the bucket ACL does
+    not allow public write access\.
+
+
+    The rule is noncompliant when:
+
+    + If the Block Public Access setting does not restrict public policies, AWS Config
+    evaluates whether the policy allows public write access\. If the policy allows
+    public write access, the rule is noncompliant\.
+
+    + If the Block Public Access setting does not restrict public bucket ACLs, AWS
+    Config evaluates whether the bucket ACL allows public write access\. If the bucket
+    ACL allows public write access, the rule is noncompliant\.'
+  File: s3-bucket-public-write-prohibited.md
+  FullDocumentation: "# s3\\-bucket\\-public\\-write\\-prohibited<a name=\"s3-bucket-public-write-prohibited\"\
+    ></a>\n\nChecks if your Amazon S3 buckets do not allow public write access\\.\
+    \ The rule checks the Block Public Access settings, the bucket policy, and the\
+    \ bucket access control list \\(ACL\\)\\.\n\nThe rule is compliant when both of\
+    \ the following are true:\n+ The Block Public Access setting restricts public\
+    \ policies or the bucket policy does not allow public write access\\.\n+ The Block\
+    \ Public Access setting restricts public ACLs or the bucket ACL does not allow\
+    \ public write access\\.\n\nThe rule is noncompliant when:\n+ If the Block Public\
+    \ Access setting does not restrict public policies, AWS Config evaluates whether\
+    \ the policy allows public write access\\. If the policy allows public write access,\
+    \ the rule is noncompliant\\.\n+ If the Block Public Access setting does not restrict\
+    \ public bucket ACLs, AWS Config evaluates whether the bucket ACL allows public\
+    \ write access\\. If the bucket ACL allows public write access, the rule is noncompliant\\\
+    .\n\n**Identifier:** S3\\_BUCKET\\_PUBLIC\\_WRITE\\_PROHIBITED\n\n**Trigger type:**\
+    \ Configuration changes and Periodic\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d447c23\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_PUBLIC_WRITE_PROHIBITED
+  Name: s3-bucket-public-write-prohibited
+  TriggerType: Configuration changes and Periodic
+- AWSRegion: All supported AWS regions
+  Description: Checks whether the Amazon S3 buckets have cross\-region replication
+    enabled\.
+  File: s3-bucket-replication-enabled.md
+  FullDocumentation: "# s3\\-bucket\\-replication\\-enabled<a name=\"s3-bucket-replication-enabled\"\
+    ></a>\n\nChecks whether the Amazon S3 buckets have cross\\-region replication\
+    \ enabled\\. \n\n**Identifier:** S3\\_BUCKET\\_REPLICATION\\_ENABLED\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d449c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_REPLICATION_ENABLED
+  Name: s3-bucket-replication-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if your Amazon S3 bucket either has the Amazon S3 default encryption
+    enabled or that the Amazon S3 bucket policy explicitly denies `put-object` requests
+    without server side encryption that uses AES\-256 or AWS Key Management Service\.
+    The rule is NON\_COMPLIANT if your Amazon S3 bucket is not encrypted by default\.
+  File: s3-bucket-server-side-encryption-enabled.md
+  FullDocumentation: "# s3\\-bucket\\-server\\-side\\-encryption\\-enabled<a name=\"\
+    s3-bucket-server-side-encryption-enabled\"></a>\n\nChecks if your Amazon S3 bucket\
+    \ either has the Amazon S3 default encryption enabled or that the Amazon S3 bucket\
+    \ policy explicitly denies `put-object` requests without server side encryption\
+    \ that uses AES\\-256 or AWS Key Management Service\\. The rule is NON\\_COMPLIANT\
+    \ if your Amazon S3 bucket is not encrypted by default\\.\n\n**Identifier:** S3\\\
+    _BUCKET\\_SERVER\\_SIDE\\_ENCRYPTION\\_ENABLED\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\n\
+    None  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d451c15\"></a>\n\
+    \nTo create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED
+  Name: s3-bucket-server-side-encryption-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if Amazon S3 buckets have policies that require requests to
+    use Secure Socket Layer \(SSL\)\. The rule is COMPLIANT if buckets explicitly
+    deny access to HTTP requests\. The rule is NON\_COMPLIANT if bucket policies allow
+    HTTP requests\.
+  File: s3-bucket-ssl-requests-only.md
+  FullDocumentation: "# s3\\-bucket\\-ssl\\-requests\\-only<a name=\"s3-bucket-ssl-requests-only\"\
+    ></a>\n\nChecks if Amazon S3 buckets have policies that require requests to use\
+    \ Secure Socket Layer \\(SSL\\)\\. The rule is COMPLIANT if buckets explicitly\
+    \ deny access to HTTP requests\\. The rule is NON\\_COMPLIANT if bucket policies\
+    \ allow HTTP requests\\.\n\n**Identifier:** S3\\_BUCKET\\_SSL\\_REQUESTS\\_ONLY\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d453c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: S3_BUCKET_SSL_REQUESTS_ONLY
+  Name: s3-bucket-ssl-requests-only
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if versioning is enabled for your S3 buckets\. Optionally, the
+    rule checks if MFA delete is enabled for your S3 buckets\.
+  File: s3-bucket-versioning-enabled.md
+  FullDocumentation: "# s3\\-bucket\\-versioning\\-enabled<a name=\"s3-bucket-versioning-enabled\"\
+    ></a>\n\nChecks if versioning is enabled for your S3 buckets\\. Optionally, the\
+    \ rule checks if MFA delete is enabled for your S3 buckets\\.\n\n**Identifier:**\
+    \ S3\\_BUCKET\\_VERSIONING\\_ENABLED\n\n**Trigger type:** Configuration changes\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nisMfaDeleteEnabled\
+    \ \\(Optional\\)Type: String  \nMFA delete is enabled for your S3 buckets\\.\n\
+    \n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d455c15\"></a>\n\nTo\
+    \ create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_BUCKET_VERSIONING_ENABLED
+  Name: s3-bucket-versioning-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks whether the Amazon S3 buckets are encrypted with AWS Key Management
+    Service\(AWS KMS\)\. The rule is NON\_COMPLIANT if the Amazon S3 bucket is not
+    encrypted with AWS KMS key\.
+  File: s3-default-encryption-kms.md
+  FullDocumentation: "# s3\\-default\\-encryption\\-kms<a name=\"s3-default-encryption-kms\"\
+    ></a>\n\nChecks whether the Amazon S3 buckets are encrypted with AWS Key Management\
+    \ Service\\(AWS KMS\\)\\. The rule is NON\\_COMPLIANT if the Amazon S3 bucket\
+    \ is not encrypted with AWS KMS key\\. \n\n**Identifier:** S3\\_DEFAULT\\_ENCRYPTION\\\
+    _KMS\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nkmsKeyArns \\(Optional\\)Type: CSV  \nComma separated list\
+    \ of AWS KMS key ARNs allowed for encrypting Amazon S3 Buckets\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d457c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_DEFAULT_ENCRYPTION_KMS
+  Name: s3-default-encryption-kms
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if Amazon S3 Events Notifications are enabled on an S3 bucket\.
+    The rule is NON\_COMPLIANT if S3 Events Notifications are not set on a bucket,
+    or if the event type or destination do not match the `eventTypes` and destinationArn
+    parameters\.
+  File: s3-event-notifications-enabled.md
+  FullDocumentation: "# s3\\-event\\-notifications\\-enabled<a name=\"s3-event-notifications-enabled\"\
+    ></a>\n\nChecks if Amazon S3 Events Notifications are enabled on an S3 bucket\\\
+    . The rule is NON\\_COMPLIANT if S3 Events Notifications are not set on a bucket,\
+    \ or if the event type or destination do not match the `eventTypes` and destinationArn\
+    \ parameters\\. \n\n**Identifier:** S3\\_EVENT\\_NOTIFICATIONS\\_ENABLED\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions\n\
+    \n**Parameters:**\n\ndestinationArn \\(Optional\\)Type: String  \nThe Amazon Resource\
+    \ Name \\(ARN\\) of the destination for the event notification \\(Amazon SNS topic,\
+    \ AWS Lambda, Amazon SQS Queue\\)\\.\n\neventTypes \\(Optional\\)Type: CSV  \n\
+    Comma\\-separated list of the preferred Amazon S3 event types\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d459c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_EVENT_NOTIFICATIONS_ENABLED
+  Name: s3-event-notifications-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if Amazon Simple Storage Service \(Amazon S3\) version enabled
+    buckets have lifecycle policy configured\. The rule is NON\_COMPLIANT if Amazon
+    S3 lifecycle policy is not enabled\.
+  File: s3-version-lifecycle-policy-check.md
+  FullDocumentation: "# s3\\-version\\-lifecycle\\-policy\\-check<a name=\"s3-version-lifecycle-policy-check\"\
+    ></a>\n\nChecks if Amazon Simple Storage Service \\(Amazon S3\\) version enabled\
+    \ buckets have lifecycle policy configured\\. The rule is NON\\_COMPLIANT if Amazon\
+    \ S3 lifecycle policy is not enabled\\. \n\n**Identifier:** S3\\_VERSION\\_LIFECYCLE\\\
+    _POLICY\\_CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions\n\n**Parameters:**\n\nbucketNames \\(Optional\\)Type:\
+    \ CSV  \nComma\\-separated list of Amazon S3 bucket names that have lifecycle\
+    \ policy enabled\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d461c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: S3_VERSION_LIFECYCLE_POLICY_CHECK
+  Name: s3-version-lifecycle-policy-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe
+    \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether AWS Key Management Service \(KMS\) key is configured
+    for an Amazon SageMaker endpoint configuration\. The rule is NON\_COMPLIANT if
+    'KmsKeyId' is not specified for the Amazon SageMaker endpoint configuration\.
+  File: sagemaker-endpoint-configuration-kms-key-configured.md
+  FullDocumentation: "# sagemaker\\-endpoint\\-configuration\\-kms\\-key\\-configured<a\
+    \ name=\"sagemaker-endpoint-configuration-kms-key-configured\"></a>\n\nChecks\
+    \ whether AWS Key Management Service \\(KMS\\) key is configured for an Amazon\
+    \ SageMaker endpoint configuration\\. The rule is NON\\_COMPLIANT if 'KmsKeyId'\
+    \ is not specified for the Amazon SageMaker endpoint configuration\\. \n\n**Identifier:**\
+    \ SAGEMAKER\\_ENDPOINT\\_CONFIGURATION\\_KMS\\_KEY\\_CONFIGURED\n\n**Trigger type:**\
+    \ Periodic\n\n**AWS Region:** All supported AWS regions except China \\(Beijing\\\
+    ), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nkmsKeyArns \\(Optional\\)Type: String  \nComma\\-separated\
+    \ list of specific AWS KMS key ARNs allowed for an Amazon SageMaker endpoint configuration\\\
+    .\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d463c15\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SAGEMAKER_ENDPOINT_CONFIGURATION_KMS_KEY_CONFIGURED
+  Name: sagemaker-endpoint-configuration-kms-key-configured
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe
+    \(Milan\), Africa \(Cape Town\) Region
+  Description: Check whether an AWS Key Management Service \(KMS\) key is configured
+    for an Amazon SageMaker notebook instance\. The rule is NON\_COMPLIANT if 'KmsKeyId'
+    is not specified for the Amazon SageMaker notebook instance\.
+  File: sagemaker-notebook-instance-kms-key-configured.md
+  FullDocumentation: "# sagemaker\\-notebook\\-instance\\-kms\\-key\\-configured<a\
+    \ name=\"sagemaker-notebook-instance-kms-key-configured\"></a>\n\nCheck whether\
+    \ an AWS Key Management Service \\(KMS\\) key is configured for an Amazon SageMaker\
+    \ notebook instance\\. The rule is NON\\_COMPLIANT if 'KmsKeyId' is not specified\
+    \ for the Amazon SageMaker notebook instance\\. \n\n**Identifier:** SAGEMAKER\\\
+    _NOTEBOOK\\_INSTANCE\\_KMS\\_KEY\\_CONFIGURED\n\n**Trigger type:** Periodic\n\n\
+    **AWS Region:** All supported AWS regions except China \\(Beijing\\), China \\\
+    (Ningxia\\), AWS GovCloud \\(US\\-East\\), Asia Pacific \\(Jakarta\\), Asia Pacific\
+    \ \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\
+    \nkmsKeyArns \\(Optional\\)Type: String  \nComma\\-separated list of AWS KMS key\
+    \ ARNs allowed for an Amazon SageMaker notebook instance\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d465c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SAGEMAKER_NOTEBOOK_INSTANCE_KMS_KEY_CONFIGURED
+  Name: sagemaker-notebook-instance-kms-key-configured
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe
+    \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether direct internet access is disabled for an Amazon SageMaker
+    notebook instance\. The rule is NON\_COMPLIANT if Amazon SageMaker notebook instances
+    are internet\-enabled\.
+  File: sagemaker-notebook-no-direct-internet-access.md
+  FullDocumentation: "# sagemaker\\-notebook\\-no\\-direct\\-internet\\-access<a name=\"\
+    sagemaker-notebook-no-direct-internet-access\"></a>\n\nChecks whether direct internet\
+    \ access is disabled for an Amazon SageMaker notebook instance\\. The rule is\
+    \ NON\\_COMPLIANT if Amazon SageMaker notebook instances are internet\\-enabled\\\
+    . \n\n**Identifier:** SAGEMAKER\\_NOTEBOOK\\_NO\\_DIRECT\\_INTERNET\\_ACCESS\n\
+    \n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa\
+    \ \\(Cape Town\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d467c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SAGEMAKER_NOTEBOOK_NO_DIRECT_INTERNET_ACCESS
+  Name: sagemaker-notebook-no-direct-internet-access
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: "Checks if AWS Secrets Manager secret has rotation enabled\\. The rule\
+    \ also checks an optional `maximumAllowedRotationFrequency` parameter\\. If the\
+    \ parameter is specified, the rotation frequency of the secret is compared with\
+    \ the maximum allowed frequency\\. The rule is NON\\_COMPLIANT if the secret is\
+    \ not scheduled for rotation\\. The rule is also NON\\_COMPLIANT if the rotation\
+    \ frequency is higher than the number specified in the maximumAllowedRotationFrequency\
+    \ parameter\\.\n\n**Note**  \nRe\\-evaluating this rule within 4 hours of the\
+    \ first evaluation will have no effect on the results\\."
+  File: secretsmanager-rotation-enabled-check.md
+  FullDocumentation: "# secretsmanager\\-rotation\\-enabled\\-check<a name=\"secretsmanager-rotation-enabled-check\"\
+    ></a>\n\nChecks if AWS Secrets Manager secret has rotation enabled\\. The rule\
+    \ also checks an optional `maximumAllowedRotationFrequency` parameter\\. If the\
+    \ parameter is specified, the rotation frequency of the secret is compared with\
+    \ the maximum allowed frequency\\. The rule is NON\\_COMPLIANT if the secret is\
+    \ not scheduled for rotation\\. The rule is also NON\\_COMPLIANT if the rotation\
+    \ frequency is higher than the number specified in the maximumAllowedRotationFrequency\
+    \ parameter\\.\n\n**Note**  \nRe\\-evaluating this rule within 4 hours of the\
+    \ first evaluation will have no effect on the results\\. \n\n**Identifier:** SECRETSMANAGER\\\
+    _ROTATION\\_ENABLED\\_CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS\
+    \ Region:** All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia\
+    \ Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nmaximumAllowedRotationFrequency\
+    \ \\(Optional\\)Type: int  \nMaximum allowed rotation frequency of the secret\
+    \ in days\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d469c17\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SECRETSMANAGER_ROTATION_ENABLED_CHECK
+  Name: secretsmanager-rotation-enabled-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: "Checks whether AWS Secrets Manager secret rotation has triggered/started\
+    \ successfully as per the rotation schedule\\. The rule returns NON\\_COMPLIANT\
+    \ if `RotationOccurringAsScheduled` is false\\. \n\n**Note**  \nThe rule returns\
+    \ NOT\\_APPLICABLE for secrets without rotation\\."
+  File: secretsmanager-scheduled-rotation-success-check.md
+  FullDocumentation: "# secretsmanager\\-scheduled\\-rotation\\-success\\-check<a\
+    \ name=\"secretsmanager-scheduled-rotation-success-check\"></a>\n\nChecks whether\
+    \ AWS Secrets Manager secret rotation has triggered/started successfully as per\
+    \ the rotation schedule\\. The rule returns NON\\_COMPLIANT if `RotationOccurringAsScheduled`\
+    \ is false\\. \n\n**Note**  \nThe rule returns NOT\\_APPLICABLE for secrets without\
+    \ rotation\\.\n\n**Identifier:** SECRETSMANAGER\\_SCHEDULED\\_ROTATION\\_SUCCESS\\\
+    _CHECK\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d471c17\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SECRETSMANAGER_SCHEDULED_ROTATION_SUCCESS_CHECK
+  Name: secretsmanager-scheduled-rotation-success-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Osaka\) Region
+  Description: "Checks if AWS Secrets Manager secrets have been rotated in the past\
+    \ specified number of days\\. The rule is NON\\_COMPLIANT if a secret has not\
+    \ been rotated for more than \u2018maxDaysSinceRotation\u2019 number of days\\\
+    . The default value is 90 days\\."
+  File: secretsmanager-secret-periodic-rotation.md
+  FullDocumentation: "# secretsmanager\\-secret\\-periodic\\-rotation<a name=\"secretsmanager-secret-periodic-rotation\"\
+    ></a>\n\nChecks if AWS Secrets Manager secrets have been rotated in the past specified\
+    \ number of days\\. The rule is NON\\_COMPLIANT if a secret has not been rotated\
+    \ for more than \u2018maxDaysSinceRotation\u2019 number of days\\. The default\
+    \ value is 90 days\\.\n\n**Identifier:** SECRETSMANAGER\\_SECRET\\_PERIODIC\\\
+    _ROTATION\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions\
+    \ except China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\\
+    ), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\
+    \nmaxDaysSinceRotation \\(Optional\\)Type: int  \nMaximum number of days in which\
+    \ a secret can remain unchanged\\. The default value is 90 days\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d473c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SECRETSMANAGER_SECRET_PERIODIC_ROTATION
+  Name: secretsmanager-secret-periodic-rotation
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: "Checks if AWS Secrets Manager secrets have been accessed within a\
+    \ specified number of days\\. The rule is NON\\_COMPLIANT if a secret has not\
+    \ been accessed in \u2018unusedForDays\u2019 number of days\\. The default value\
+    \ is 90 days\\."
+  File: secretsmanager-secret-unused.md
+  FullDocumentation: "# secretsmanager\\-secret\\-unused<a name=\"secretsmanager-secret-unused\"\
+    ></a>\n\nChecks if AWS Secrets Manager secrets have been accessed within a specified\
+    \ number of days\\. The rule is NON\\_COMPLIANT if a secret has not been accessed\
+    \ in \u2018unusedForDays\u2019 number of days\\. The default value is 90 days\\\
+    .\n\n**Identifier:** SECRETSMANAGER\\_SECRET\\_UNUSED\n\n**Trigger type:** Periodic\n\
+    \n**AWS Region:** All supported AWS regions except China \\(Beijing\\), China\
+    \ \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\n\
+    unusedForDays \\(Optional\\)Type: int  \nThe number of days in which a secret\
+    \ can remain unused\\. The default value is 90 days\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d475c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SECRETSMANAGER_SECRET_UNUSED
+  Name: secretsmanager-secret-unused
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if all secrets in AWS Secrets Manager are encrypted using the
+    AWS managed key \(`aws/secretsmanager`\) or a customer managed key that you created
+    in AWS Key Management Service \(AWS KMS\)\. This rule is COMPLIANT if a secret
+    is encrypted using a customer managed key\. This rule is NON\_COMPLIANT if a secret
+    is encrypted using `aws/secretsmanager`\.
+  File: secretsmanager-using-cmk.md
+  FullDocumentation: "# secretsmanager\\-using\\-cmk<a name=\"secretsmanager-using-cmk\"\
+    ></a>\n\nChecks if all secrets in AWS Secrets Manager are encrypted using the\
+    \ AWS managed key \\(`aws/secretsmanager`\\) or a customer managed key that you\
+    \ created in AWS Key Management Service \\(AWS KMS\\)\\. This rule is COMPLIANT\
+    \ if a secret is encrypted using a customer managed key\\. This rule is NON\\\
+    _COMPLIANT if a secret is encrypted using `aws/secretsmanager`\\. \n\n**Identifier:**\
+    \ SECRETSMANAGER\\_USING\\_CMK\n\n**Trigger type:** Configuration changes\n\n\
+    **AWS Region:** All supported AWS regions except China \\(Beijing\\), China \\\
+    (Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia\
+    \ Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\n\
+    kmsKeyArns \\(Optional\\)Type: CSV  \nComma\\-separated list of KMS key Amazon\
+    \ Resource Names \\(ARNs\\) to check if the keys are used in the encryption\\\
+    .\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d477c15\"></a>\n\n\
+    To create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SECRETSMANAGER_USING_CMK
+  Name: secretsmanager-using-cmk
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape
+    Town\) Region
+  Description: Checks that AWS Security Hub is enabled for an AWS Account\. The rule
+    is NON\_COMPLIANT if AWS Security Hub is not enabled\.
+  File: securityhub-enabled.md
+  FullDocumentation: "# securityhub\\-enabled<a name=\"securityhub-enabled\"></a>\n\
+    \nChecks that AWS Security Hub is enabled for an AWS Account\\. The rule is NON\\\
+    _COMPLIANT if AWS Security Hub is not enabled\\. \n\n**Identifier:** SECURITYHUB\\\
+    _ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions\
+    \ except China \\(Beijing\\), China \\(Ningxia\\), Asia Pacific \\(Jakarta\\),\
+    \ Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d479c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SECURITYHUB_ENABLED
+  Name: securityhub-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks whether Service Endpoint for the service provided in rule parameter
+    is created for each Amazon VPC\. The rule returns NON\_COMPLIANT if an Amazon
+    VPC doesn't have a VPC endpoint created for the service\.
+  File: service-vpc-endpoint-enabled.md
+  FullDocumentation: "# service\\-vpc\\-endpoint\\-enabled<a name=\"service-vpc-endpoint-enabled\"\
+    ></a>\n\nChecks whether Service Endpoint for the service provided in rule parameter\
+    \ is created for each Amazon VPC\\. The rule returns NON\\_COMPLIANT if an Amazon\
+    \ VPC doesn't have a VPC endpoint created for the service\\. \n\n**Identifier:**\
+    \ SERVICE\\_VPC\\_ENDPOINT\\_ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:**\
+    \ All supported AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\\
+    (Osaka\\) Region\n\n**Parameters:**\n\nserviceNameType: String  \nThe short name\
+    \ or suffix for the service\\. Note: To get a list of available service names\
+    \ or valid suffix list, use DescribeVpcEndpointServices\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d481c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SERVICE_VPC_ENDPOINT_ENABLED
+  Name: service-vpc-endpoint-enabled
+  TriggerType: Periodic
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: "Checks if AWS Shield Advanced is enabled in your AWS account and this\
+    \ subscription is set to automatically renew\\.\n\n**Note**  \nThe API endpoint\
+    \ of AWS Shield Advanced is only available in US East \\(N\\. Virginia\\) Region\\\
+    . This rule should only be scheduled to run in the US East \\(N\\. Virginia\\\
+    ) Region\\."
+  File: shield-advanced-enabled-autorenew.md
+  FullDocumentation: "# shield\\-advanced\\-enabled\\-autorenew<a name=\"shield-advanced-enabled-autorenew\"\
+    ></a>\n\nChecks if AWS Shield Advanced is enabled in your AWS account and this\
+    \ subscription is set to automatically renew\\.\n\n**Note**  \nThe API endpoint\
+    \ of AWS Shield Advanced is only available in US East \\(N\\. Virginia\\) Region\\\
+    . This rule should only be scheduled to run in the US East \\(N\\. Virginia\\\
+    ) Region\\.\n\n**Identifier:** SHIELD\\_ADVANCED\\_ENABLED\\_AUTORENEW\n\n**Trigger\
+    \ type:** Periodic\n\n**AWS Region:** Only available in US East \\(N\\. Virginia\\\
+    ) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d483c17\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: SHIELD_ADVANCED_ENABLED_AUTORENEW
+  Name: shield-advanced-enabled-autorenew
+  TriggerType: Periodic
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if the Shield Response Team \(SRT\) can access your AWS account\.
+    The rule is NON\_COMPLIANT if AWS Shield Advanced is enabled but the role for
+    SRT access is not configured\.
+  File: shield-drt-access.md
+  FullDocumentation: "# shield\\-drt\\-access<a name=\"shield-drt-access\"></a>\n\n\
+    Checks if the Shield Response Team \\(SRT\\) can access your AWS account\\. The\
+    \ rule is NON\\_COMPLIANT if AWS Shield Advanced is enabled but the role for SRT\
+    \ access is not configured\\.\n\n**Identifier:** SHIELD\\_DRT\\_ACCESS\n\n**Trigger\
+    \ type:** Periodic\n\n**AWS Region:** Only available in US East \\(N\\. Virginia\\\
+    ) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d485c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: SHIELD_DRT_ACCESS
+  Name: shield-drt-access
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks if Amazon SNS topic is encrypted with AWS Key Management Service
+    \(AWS KMS\)\. The rule is NON\_COMPLIANT if the Amazon SNS topic is not encrypted
+    with AWS KMS\. The rule is also NON\_COMPLIANT when encrypted KMS key is not present
+    in `kmsKeyIds` input parameter\.
+  File: sns-encrypted-kms.md
+  FullDocumentation: "# sns\\-encrypted\\-kms<a name=\"sns-encrypted-kms\"></a>\n\n\
+    Checks if Amazon SNS topic is encrypted with AWS Key Management Service \\(AWS\
+    \ KMS\\)\\. The rule is NON\\_COMPLIANT if the Amazon SNS topic is not encrypted\
+    \ with AWS KMS\\. The rule is also NON\\_COMPLIANT when encrypted KMS key is not\
+    \ present in `kmsKeyIds` input parameter\\.\n\n**Identifier:** SNS\\_ENCRYPTED\\\
+    _KMS\n\n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nkmsKeyIds \\(Optional\\)Type: CSV  \nComma separated list\
+    \ of AWS KMS key ARNs allowed for encrypting Amazon SNS Topic\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d487c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SNS_ENCRYPTED_KMS
+  Name: sns-encrypted-kms
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if Amazon Simple Notification Service \(SNS\) logging is enabled
+    for the delivery status of notification messages sent to a topic for the endpoints\.
+    The rule is NON\_COMPLIANT if the delivery status notification for messages is
+    not enabled\.
+  File: sns-topic-message-delivery-notification-enabled.md
+  FullDocumentation: "# sns\\-topic\\-message\\-delivery\\-notification\\-enabled<a\
+    \ name=\"sns-topic-message-delivery-notification-enabled\"></a>\n\nChecks if Amazon\
+    \ Simple Notification Service \\(SNS\\) logging is enabled for the delivery status\
+    \ of notification messages sent to a topic for the endpoints\\. The rule is NON\\\
+    _COMPLIANT if the delivery status notification for messages is not enabled\\.\
+    \ \n\n**Identifier:** SNS\\_TOPIC\\_MESSAGE\\_DELIVERY\\_NOTIFICATION\\_ENABLED\n\
+    \n**Trigger type:** Configuration changes\n\n**AWS Region:** All supported AWS\
+    \ regions\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"\
+    w76aac11c31c17b7d489c15\"></a>\n\nTo create AWS Config managed rules with AWS\
+    \ CloudFormation templates, see [Creating AWS Config Managed Rules With AWS CloudFormation\
+    \ Templates](aws-config-managed-rules-cloudformation-templates.md)\\."
+  Identifier: SNS_TOPIC_MESSAGE_DELIVERY_NOTIFICATION_ENABLED
+  Name: sns-topic-message-delivery-notification-enabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions
+  Description: Checks if AWS Systems Manager documents owned by the account are public\.
+    This rule is NON\_COMPLIANT if SSM documents with owner 'Self' are public\.
+  File: ssm-document-not-public.md
+  FullDocumentation: "# ssm\\-document\\-not\\-public<a name=\"ssm-document-not-public\"\
+    ></a>\n\nChecks if AWS Systems Manager documents owned by the account are public\\\
+    . This rule is NON\\_COMPLIANT if SSM documents with owner 'Self' are public\\\
+    . \n\n**Identifier:** SSM\\_DOCUMENT\\_NOT\\_PUBLIC\n\n**Trigger type:** Periodic\n\
+    \n**AWS Region:** All supported AWS regions\n\n**Parameters:**\n\nNone  \n\n##\
+    \ AWS CloudFormation template<a name=\"w76aac11c31c17b7d491c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SSM_DOCUMENT_NOT_PUBLIC
+  Name: ssm-document-not-public
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if Amazon Virtual Private Cloud \(Amazon VPC\) subnets are assigned
+    a public IP address\. The rule is COMPLIANT if Amazon VPC does not have subnets
+    that are assigned a public IP address\. The rule is NON\_COMPLIANT if Amazon VPC
+    has subnets that are assigned a public IP address\.
+  File: subnet-auto-assign-public-ip-disabled.md
+  FullDocumentation: "# subnet\\-auto\\-assign\\-public\\-ip\\-disabled<a name=\"\
+    subnet-auto-assign-public-ip-disabled\"></a>\n\nChecks if Amazon Virtual Private\
+    \ Cloud \\(Amazon VPC\\) subnets are assigned a public IP address\\. The rule\
+    \ is COMPLIANT if Amazon VPC does not have subnets that are assigned a public\
+    \ IP address\\. The rule is NON\\_COMPLIANT if Amazon VPC has subnets that are\
+    \ assigned a public IP address\\. \n\n**Identifier:** SUBNET\\_AUTO\\_ASSIGN\\\
+    _PUBLIC\\_IP\\_DISABLED\n\n**Trigger type:** Configuration changes\n\n**AWS Region:**\
+    \ All supported AWS regions except China \\(Beijing\\), China \\(Ningxia\\), AWS\
+    \ GovCloud \\(US\\-East\\), AWS GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\\
+    ), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d493c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: SUBNET_AUTO_ASSIGN_PUBLIC_IP_DISABLED
+  Name: subnet-auto-assign-public-ip-disabled
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Osaka\), Europe \(Milan\),
+    Africa \(Cape Town\) Region
+  Description: Checks if AWS Backup\-Gateway VirtualMachines are protected by a backup
+    plan\. The rule is NON\_COMPLIANT if the Backup\-Gateway VirtualMachine is not
+    covered by a backup plan\.
+  File: virtualmachine-resources-protected-by-backup-plan.md
+  FullDocumentation: "# virtualmachine\\-resources\\-protected\\-by\\-backup\\-plan<a\
+    \ name=\"virtualmachine-resources-protected-by-backup-plan\"></a>\n\nChecks if\
+    \ AWS Backup\\-Gateway VirtualMachines are protected by a backup plan\\. The rule\
+    \ is NON\\_COMPLIANT if the Backup\\-Gateway VirtualMachine is not covered by\
+    \ a backup plan\\. \n\n**Identifier:** VIRTUALMACHINE\\_RESOURCES\\_PROTECTED\\\
+    _BY\\_BACKUP\\_PLAN\n\n**Trigger type:** Periodic\n\n**AWS Region:** All supported\
+    \ AWS regions except Asia Pacific \\(Osaka\\), Europe \\(Milan\\), Africa \\(Cape\
+    \ Town\\) Region\n\n**Parameters:**\n\nresourceTags \\(Optional\\)Type: String\
+    \  \nTags for AWS Backup\\-Gateway VirtualMachines for the rule to check, in JSON\
+    \ format\\.\n\nresourceId \\(Optional\\)Type: String  \nID of AWS Backup\\-Gateway\
+    \ VirtualMachine for the rule to check\\.\n\ncrossRegionList \\(Optional\\)Type:\
+    \ String  \nComma\\-separated list of destination regions for the cross\\-region\
+    \ backup copy to be kept\n\ncrossAccountList \\(Optional\\)Type: String  \nComma\\\
+    -separated list of destination accounts for cross\\-account backup copy to be\
+    \ kept\n\nmaxRetentionDays \\(Optional\\)Type: int  \nThe maximum retention period\
+    \ in days for the Backup Vault Lock\n\nminRetentionDays \\(Optional\\)Type: int\
+    \  \nThe minimum retention period in days for the Backup Vault Lock\n\nbackupVaultLockCheck\
+    \ \\(Optional\\)Type: String  \nAccepted values: 'True' or 'False'\\. Enter 'True'\
+    \ for the rule to check if the resource is backed up in a locked vault\n\n## AWS\
+    \ CloudFormation template<a name=\"w76aac11c31c17b7d495c15\"></a>\n\nTo create\
+    \ AWS Config managed rules with AWS CloudFormation templates, see [Creating AWS\
+    \ Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: VIRTUALMACHINE_RESOURCES_PROTECTED_BY_BACKUP_PLAN
+  Name: virtualmachine-resources-protected-by-backup-plan
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\) Region
+  Description: Checks that the default security group of any Amazon Virtual Private
+    Cloud \(VPC\) does not allow inbound or outbound traffic\. The rule returns NOT\_APPLICABLE
+    if the security group is not default\. The rule is NON\_COMPLIANT if the default
+    security group has one or more inbound or outbound traffic rules\.
+  File: vpc-default-security-group-closed.md
+  FullDocumentation: "# vpc\\-default\\-security\\-group\\-closed<a name=\"vpc-default-security-group-closed\"\
+    ></a>\n\nChecks that the default security group of any Amazon Virtual Private\
+    \ Cloud \\(VPC\\) does not allow inbound or outbound traffic\\. The rule returns\
+    \ NOT\\_APPLICABLE if the security group is not default\\. The rule is NON\\_COMPLIANT\
+    \ if the default security group has one or more inbound or outbound traffic rules\\\
+    .\n\n**Identifier:** VPC\\_DEFAULT\\_SECURITY\\_GROUP\\_CLOSED\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except Asia\
+    \ Pacific \\(Jakarta\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d497c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: VPC_DEFAULT_SECURITY_GROUP_CLOSED
+  Name: vpc-default-security-group-closed
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\) Region
+  Description: Checks whether Amazon Virtual Private Cloud flow logs are found and
+    enabled for Amazon VPC\.
+  File: vpc-flow-logs-enabled.md
+  FullDocumentation: "# vpc\\-flow\\-logs\\-enabled<a name=\"vpc-flow-logs-enabled\"\
+    ></a>\n\nChecks whether Amazon Virtual Private Cloud flow logs are found and enabled\
+    \ for Amazon VPC\\. \n\n**Identifier:** VPC\\_FLOW\\_LOGS\\_ENABLED\n\n**Trigger\
+    \ type:** Periodic\n\n**AWS Region:** All supported AWS regions except Asia Pacific\
+    \ \\(Jakarta\\) Region\n\n**Parameters:**\n\ntrafficType \\(Optional\\)Type: String\
+    \  \nTrafficType of flow logs\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d499c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: VPC_FLOW_LOGS_ENABLED
+  Name: vpc-flow-logs-enabled
+  TriggerType: Periodic
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\) Region
+  Description: Checks if there are unused network access control lists \(network ACLs\)\.
+    The rule is COMPLIANT if each network ACL is associated with a subnet\. The rule
+    is NON\_COMPLIANT if a network ACL is not associated with a subnet\.
+  File: vpc-network-acl-unused-check.md
+  FullDocumentation: "# vpc\\-network\\-acl\\-unused\\-check<a name=\"vpc-network-acl-unused-check\"\
+    ></a>\n\nChecks if there are unused network access control lists \\(network ACLs\\\
+    )\\. The rule is COMPLIANT if each network ACL is associated with a subnet\\.\
+    \ The rule is NON\\_COMPLIANT if a network ACL is not associated with a subnet\\\
+    .\n\n**Identifier:** VPC\\_NETWORK\\_ACL\\_UNUSED\\_CHECK\n\n**Trigger type:**\
+    \ Configuration changes\n\n**AWS Region:** All supported AWS regions except China\
+    \ \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS GovCloud\
+    \ \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d501c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: VPC_NETWORK_ACL_UNUSED_CHECK
+  Name: vpc-network-acl-unused-check
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except Asia Pacific \(Jakarta\), Asia Pacific
+    \(Osaka\) Region
+  Description: Checks whether any security groups with inbound 0\.0\.0\.0/0 have TCP
+    or UDP ports accessible\. The rule is NON\_COMPLIANT when a security group with
+    inbound 0\.0\.0\.0/0 has a port accessible which is not specified in the rule
+    parameters\.
+  File: vpc-sg-open-only-to-authorized-ports.md
+  FullDocumentation: "# vpc\\-sg\\-open\\-only\\-to\\-authorized\\-ports<a name=\"\
+    vpc-sg-open-only-to-authorized-ports\"></a>\n\nChecks whether any security groups\
+    \ with inbound 0\\.0\\.0\\.0/0 have TCP or UDP ports accessible\\. The rule is\
+    \ NON\\_COMPLIANT when a security group with inbound 0\\.0\\.0\\.0/0 has a port\
+    \ accessible which is not specified in the rule parameters\\. \n\n**Identifier:**\
+    \ VPC\\_SG\\_OPEN\\_ONLY\\_TO\\_AUTHORIZED\\_PORTS\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** All supported AWS regions except Asia Pacific \\\
+    (Jakarta\\), Asia Pacific \\(Osaka\\) Region\n\n**Parameters:**\n\nauthorizedTcpPorts\
+    \ \\(Optional\\)Type: String  \n Comma\\-separated list of TCP ports authorized\
+    \ to be open to 0\\.0\\.0\\.0/0\\. Ranges are defined by dash, for example, \"\
+    443,1020\\-1025\"\\.\n\nauthorizedUdpPorts \\(Optional\\)Type: String  \n Comma\\\
+    -separated list of UDP ports authorized to be open to 0\\.0\\.0\\.0/0\\. Ranges\
+    \ are defined by dash, for example, \"500,1020\\-1025\"\\.\n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d503c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: VPC_SG_OPEN_ONLY_TO_AUTHORIZED_PORTS
+  Name: vpc-sg-open-only-to-authorized-ports
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    Asia Pacific \(Jakarta\), Asia Pacific \(Osaka\), Middle East \(Bahrain\) Region
+  Description: Checks that both VPN tunnels provided by AWS Site\-to\-Site VPN are
+    in UP status\. The rule returns NON\_COMPLIANT if one or both tunnels are in DOWN
+    status\.
+  File: vpc-vpn-2-tunnels-up.md
+  FullDocumentation: "# vpc\\-vpn\\-2\\-tunnels\\-up<a name=\"vpc-vpn-2-tunnels-up\"\
+    ></a>\n\nChecks that both VPN tunnels provided by AWS Site\\-to\\-Site VPN are\
+    \ in UP status\\. The rule returns NON\\_COMPLIANT if one or both tunnels are\
+    \ in DOWN status\\. \n\n**Identifier:** VPC\\_VPN\\_2\\_TUNNELS\\_UP\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), Asia Pacific \\(Jakarta\\), Asia Pacific\
+    \ \\(Osaka\\), Middle East \\(Bahrain\\) Region\n\n**Parameters:**\n\nNone  \n\
+    \n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d505c15\"></a>\n\nTo\
+    \ create AWS Config managed rules with AWS CloudFormation templates, see [Creating\
+    \ AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: VPC_VPN_2_TUNNELS_UP
+  Name: vpc-vpn-2-tunnels-up
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if logging is enabled on AWS Web Application Firewall \(WAF\)
+    classic global web ACLs\. This rule is NON\_COMPLIANT for a global web ACL, if
+    it does not have logging enabled\.
+  File: waf-classic-logging-enabled.md
+  FullDocumentation: "# waf\\-classic\\-logging\\-enabled<a name=\"waf-classic-logging-enabled\"\
+    ></a>\n\nChecks if logging is enabled on AWS Web Application Firewall \\(WAF\\\
+    ) classic global web ACLs\\. This rule is NON\\_COMPLIANT for a global web ACL,\
+    \ if it does not have logging enabled\\. \n\n**Identifier:** WAF\\_CLASSIC\\_LOGGING\\\
+    _ENABLED\n\n**Trigger type:** Periodic\n\n**AWS Region:** Only available in US\
+    \ East \\(N\\. Virginia\\) Region\n\n**Parameters:**\n\nKinesisFirehoseDeliveryStreamArns\
+    \ \\(Optional\\)Type: CSV  \nComma separated list of Amazon Kinesis stream ARN\
+    \ for AWS WAF logs\\.\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d509c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: WAF_CLASSIC_LOGGING_ENABLED
+  Name: waf-classic-logging-enabled
+  TriggerType: Periodic
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if an AWS WAF global rule contains any conditions\. The rule
+    is NON\_COMPLIANT if no conditions are present within the WAF global rule\.
+  File: waf-global-rule-not-empty.md
+  FullDocumentation: "# waf\\-global\\-rule\\-not\\-empty<a name=\"waf-global-rule-not-empty\"\
+    ></a>\n\nChecks if an AWS WAF global rule contains any conditions\\. The rule\
+    \ is NON\\_COMPLIANT if no conditions are present within the WAF global rule\\\
+    . \n\n**Identifier:** WAF\\_GLOBAL\\_RULE\\_NOT\\_EMPTY\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** Only available in US East \\(N\\. Virginia\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d513c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: WAF_GLOBAL_RULE_NOT_EMPTY
+  Name: waf-global-rule-not-empty
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks if an AWS WAF Classic rule group contains any rules\. The rule
+    is NON\_COMPLIANT if there are no rules present within a rule group\.
+  File: waf-global-rulegroup-not-empty.md
+  FullDocumentation: "# waf\\-global\\-rulegroup\\-not\\-empty<a name=\"waf-global-rulegroup-not-empty\"\
+    ></a>\n\nChecks if an AWS WAF Classic rule group contains any rules\\. The rule\
+    \ is NON\\_COMPLIANT if there are no rules present within a rule group\\. \n\n\
+    **Identifier:** WAF\\_GLOBAL\\_RULEGROUP\\_NOT\\_EMPTY\n\n**Trigger type:** Configuration\
+    \ changes\n\n**AWS Region:** Only available in US East \\(N\\. Virginia\\) Region\n\
+    \n**Parameters:**\n\nNone  \n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d511c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: WAF_GLOBAL_RULEGROUP_NOT_EMPTY
+  Name: waf-global-rulegroup-not-empty
+  TriggerType: Configuration changes
+- AWSRegion: Only available in US East \(N\. Virginia\) Region
+  Description: Checks whether a WAF Global Web ACL contains any WAF rules or rule
+    groups\. This rule is NON\_COMPLIANT if a Web ACL does not contain any WAF rule
+    or rule group\.
+  File: waf-global-webacl-not-empty.md
+  FullDocumentation: "# waf\\-global\\-webacl\\-not\\-empty<a name=\"waf-global-webacl-not-empty\"\
+    ></a>\n\nChecks whether a WAF Global Web ACL contains any WAF rules or rule groups\\\
+    . This rule is NON\\_COMPLIANT if a Web ACL does not contain any WAF rule or rule\
+    \ group\\. \n\n**Identifier:** WAF\\_GLOBAL\\_WEBACL\\_NOT\\_EMPTY\n\n**Trigger\
+    \ type:** Configuration changes\n\n**AWS Region:** Only available in US East \\\
+    (N\\. Virginia\\) Region\n\n**Parameters:**\n\nNone  \n\n## AWS CloudFormation\
+    \ template<a name=\"w76aac11c31c17b7d515c15\"></a>\n\nTo create AWS Config managed\
+    \ rules with AWS CloudFormation templates, see [Creating AWS Config Managed Rules\
+    \ With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: WAF_GLOBAL_WEBACL_NOT_EMPTY
+  Name: waf-global-webacl-not-empty
+  TriggerType: Configuration changes
+- AWSRegion: All supported AWS regions except China \(Beijing\), China \(Ningxia\),
+    AWS GovCloud \(US\-East\), AWS GovCloud \(US\-West\), Asia Pacific \(Jakarta\),
+    Asia Pacific \(Osaka\), Europe \(Milan\), Africa \(Cape Town\) Region
+  Description: Checks whether logging is enabled on AWS Web Application Firewall \(WAFV2\)
+    regional and global web access control list \(ACLs\)\. The rule is NON\_COMPLIANT
+    if the logging is enabled but the logging destination does not match the value
+    of the parameter\.
+  File: wafv2-logging-enabled.md
+  FullDocumentation: "# wafv2\\-logging\\-enabled<a name=\"wafv2-logging-enabled\"\
+    ></a>\n\nChecks whether logging is enabled on AWS Web Application Firewall \\\
+    (WAFV2\\) regional and global web access control list \\(ACLs\\)\\. The rule is\
+    \ NON\\_COMPLIANT if the logging is enabled but the logging destination does not\
+    \ match the value of the parameter\\. \n\n**Identifier:** WAFV2\\_LOGGING\\_ENABLED\n\
+    \n**Trigger type:** Periodic\n\n**AWS Region:** All supported AWS regions except\
+    \ China \\(Beijing\\), China \\(Ningxia\\), AWS GovCloud \\(US\\-East\\), AWS\
+    \ GovCloud \\(US\\-West\\), Asia Pacific \\(Jakarta\\), Asia Pacific \\(Osaka\\\
+    ), Europe \\(Milan\\), Africa \\(Cape Town\\) Region\n\n**Parameters:**\n\nKinesisFirehoseDeliveryStreamArns\
+    \ \\(Optional\\)Type: CSV  \nComma separated list of Kinesis Firehose delivery\
+    \ stream ARNs\n\n## AWS CloudFormation template<a name=\"w76aac11c31c17b7d507c15\"\
+    ></a>\n\nTo create AWS Config managed rules with AWS CloudFormation templates,\
+    \ see [Creating AWS Config Managed Rules With AWS CloudFormation Templates](aws-config-managed-rules-cloudformation-templates.md)\\\
+    ."
+  Identifier: WAFV2_LOGGING_ENABLED
+  Name: wafv2-logging-enabled
+  TriggerType: Periodic

--- a/export_to_yaml.py
+++ b/export_to_yaml.py
@@ -1,0 +1,67 @@
+import yaml
+import os
+import re
+from os import listdir
+from operator import itemgetter
+
+all_rules = []
+
+for f in listdir("doc_source"):
+    print(f)
+
+    rule = {}
+    rule["File"] = f
+
+    id = f.replace(".md", "")
+
+    rule["Name"] = id
+    path = "doc_source/"+f
+
+    # print(path)
+    if os.path.isfile(path):
+        valid = False
+        with open(path, 'r') as infile:
+            contents = infile.read()
+            rule["FullDocumentation"] = contents.strip()
+
+            if contents.find("**Identifier:**") > 0:
+                valid = True
+            else:
+                print("   - Not a control")
+                continue
+
+            # break into lines and ignore first line
+            tmp = contents.splitlines(keepends=True)[1:]
+            tmp = ''.join(tmp).strip()
+
+            # Grab eventhing before the Identifier row
+            rule["Description"] = tmp.split("**Identifier:**")[0].strip()
+
+            m = re.search('\*\*Identifier:\*\*(.+?)\n', contents)
+            if m:
+                rule["Identifier"] = m.group(1).strip().replace("\\_", "_")
+            else:
+                rule["Identifier"] = "Unknown"
+
+            m = re.search('\*\*Trigger type:\*\*(.+?)\n', contents)
+            if m:
+                rule["TriggerType"] = m.group(1).strip()
+            else:
+                rule["TriggerType"] = "Unknown"
+
+            m = re.search('\*\*AWS Region:\*\*(.+?)\n', contents)
+            if m:
+                rule["AWSRegion"] = m.group(1).strip()
+            else:
+                rule["AWSRegion"] = "Unknown"
+
+        if valid:
+            all_rules.append(rule)
+
+    else:
+        print("NOT FOUND AWS FILE " + path)
+
+all_rules = sorted(all_rules, key=itemgetter('File'))
+
+with open('config-rules.yml', 'w') as outfile:
+    yaml.dump(all_rules, outfile, default_flow_style=False)


### PR DESCRIPTION
*Description of changes:*

This change provides a tool to convert the markdown files for the Config Rules back into a structured YAML format that can be used by other tools and systems.

Others might find this useful to have the list of config rules in YAML format for use in applications managing rules.

**If this data IS already available in a structured format, please let me know**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
