### PR TITLE
Update NIST 800-53 Rev5 to include GovCloud exclusion

### DIFF
--- a/doc_source/operational-best-practices-for-nist-800-53_rev_5.md
+++ b/doc_source/operational-best-practices-for-nist-800-53_rev_5.md
@@ -4,7 +4,7 @@ Conformance packs provide a general\-purpose compliance framework designed to en
 
 The following provides a sample mapping between the NIST 800\-53 and AWS managed Config rules\. Each Config rule applies to a specific AWS resource, and relates to one or more NIST 800\-53 controls\. A NIST 800\-53 control can be related to multiple Config rules\. Refer to the table below for more detail and guidance related to these mappings\.
 
-**AWS Region:** All supported AWS Regions except Middle East \(Bahrain\)
+**AWS Region:** All supported AWS Regions except Middle East \(Bahrain\) and AWS GovCloud (US).
 
 
 ****  


### PR DESCRIPTION
*Issue #27

*Description of changes:* Added note of no availability in GovCloud.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
