### PR TITLE
secretsmanager-secret-unused: formatting error

### DIFF
--- a/doc_source/secretsmanager-secret-unused.md
+++ b/doc_source/secretsmanager-secret-unused.md
@@ -1,6 +1,6 @@
 # secretsmanager\-secret\-unused<a name="secretsmanager-secret-unused"></a>
 
-Checks if AWS Secrets Manager secrets have been accessed within a specified number of days\. The rule is NON\_COMPLIANT if a secret has not been accessed in â€˜unusedForDaysâ€™ number of days\. The default value is 90 days\.
+Checks if AWS Secrets Manager secrets have been accessed within a specified number of days\. The rule is NON\_COMPLIANT if a secret has not been accessed in `unusedForDays` number of days\. The default value is 90 days\.
 
 **Identifier:** SECRETSMANAGER\_SECRET\_UNUSED
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Resolved a formatting error within "secretsmanager-secret-unused" - resulting in weird rendering within the documentation page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

![image](https://user-images.githubusercontent.com/8777530/207014821-bf574196-f461-4d12-ac04-e37d8683cc86.png)

