### PR TITLE
Fix 'evaluation' typo on AWS Config Manager Rules

### DIFF
--- a/doc_source/evaluate-config_use-managed-rules.md
+++ b/doc_source/evaluate-config_use-managed-rules.md
@@ -6,7 +6,7 @@ You can customize the behavior of a managed rule to suit your needs\. For exampl
 
 After you activate a rule, AWS Config compares your resources to the conditions of the rule\. There are two evaluation modes for AWS Config rules: **proactive evaluation** and **detective evaluation**\.
 
-Use *proactive evaluation* to evaluate resources prior to resource provising\. This allows you to evaluate the configuration settings of your resources before they are created or updated\. Use *detective evluation* to evaluate resources that have already been provisioned\. This allows you to evaluate the configuration settings of your existing resources\.
+Use *proactive evaluation* to evaluate resources prior to resource provising\. This allows you to evaluate the configuration settings of your resources before they are created or updated\. Use *detective evaluation* to evaluate resources that have already been provisioned\. This allows you to evaluate the configuration settings of your existing resources\.
 
 For proactive evaluation, there is only one type of trigger:
 + **Configuration changes** – AWS Config initiates the evaluation when there are changes to the configuration of a pre\-provisioned resource\. The evaluation runs after AWS Config sends a configuration item change notification\.


### PR DESCRIPTION
*Description of changes:* Fix `evaluation` typo


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
