### PR TITLE
docs: elaborate on what it means to have a "broken" IAM role

### DIFF
--- a/doc_source/delete-config-data-with-retention-period.md
+++ b/doc_source/delete-config-data-with-retention-period.md
@@ -24,7 +24,7 @@ After you specify a retention period, AWS Config APIs no longer return `Configur
 
 **Note**  
 AWS Config cannot record your `ConfigurationItems` if recording is switched off\.
-AWS Config cannot record your `ConfigurationItems` if your IAM role is broken\.
+AWS Config cannot record your `ConfigurationItems` if your IAM role has insufficient permissions\. For more information, see [Permissions for the IAM Role Assigned to AWS Config](iamrole-permissions.md)\.
 
 ## Setting Data Retention Period in AWS Management Console<a name="delete-config-data-with-retention-period-console"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Current documentation states:
```
AWS Config cannot record your `ConfigurationItems` if your IAM role is broken.
```

The changes introduced in this PR expand on what it means to have a "broken" IAM Role when it comes to AWS Config. A link back to `iamrole-permissions.md` was also introduced.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
